### PR TITLE
Fix issue #7: Resolve Minecraft 1.21 API changes

### DIFF
--- a/forge/src/main/java/com/railwayteam/railways/compat/tracks/SoftIngredient.java
+++ b/forge/src/main/java/com/railwayteam/railways/compat/tracks/SoftIngredient.java
@@ -21,18 +21,17 @@ package com.railwayteam.railways.compat.tracks;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.world.item.crafting.Ingredient;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.stream.Stream;
-
 /**
- * Represents a special ingredient for datagen - it references an item that does not necessarily exist
+ * Represents a special ingredient for datagen - it references an item that does not necessarily exist.
+ * In Minecraft 1.21+, Ingredient became final so this class no longer extends it.
+ * It provides a similar interface for use in track material registration.
  */
-public class SoftIngredient extends Ingredient {
+public class SoftIngredient {
     public final ResourceLocation item;
-    public SoftIngredient(ResourceLocation item) {
-        super(Stream.empty());
+    
+    private SoftIngredient(ResourceLocation item) {
         this.item = item;
     }
 
@@ -40,14 +39,12 @@ public class SoftIngredient extends Ingredient {
         return new SoftIngredient(item);
     }
 
-    @Override
     public @NotNull JsonElement toJson() {
         JsonObject jsonobject = new JsonObject();
         jsonobject.addProperty("item", item.toString());
         return jsonobject;
     }
 
-    @Override
     public boolean isEmpty() {
         return false;
     }

--- a/forge/src/main/java/com/railwayteam/railways/content/minecarts/MinecartJukebox.java
+++ b/forge/src/main/java/com/railwayteam/railways/content/minecarts/MinecartJukebox.java
@@ -21,6 +21,8 @@ package com.railwayteam.railways.content.minecarts;
 import com.railwayteam.railways.registry.CREntities;
 import com.railwayteam.railways.registry.CRItems;
 import com.railwayteam.railways.util.packet.PacketSender;
+import net.minecraft.core.Holder;
+import net.minecraft.core.component.DataComponents;
 import net.neoforged.api.distmarker.Dist;
 import net.neoforged.api.distmarker.OnlyIn;
 import net.minecraft.client.Minecraft;
@@ -39,7 +41,8 @@ import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.RecordItem;
+import net.minecraft.world.item.JukeboxPlayable;
+import net.minecraft.world.item.JukeboxSong;
 import net.minecraft.world.level.GameRules;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Blocks;
@@ -66,8 +69,13 @@ public class MinecartJukebox extends MinecartBlock {
   }
 
   public int getComparatorOutput() {
-    if (disc.getItem() instanceof RecordItem record) {
-      return record.getAnalogOutput();
+    // In 1.21, music discs use JukeboxPlayable component
+    JukeboxPlayable playable = disc.get(DataComponents.JUKEBOX_PLAYABLE);
+    if (playable != null) {
+      return playable.song().holder()
+        .map(Holder::value)
+        .map(JukeboxSong::comparatorOutput)
+        .orElse(0);
     }
     return 0;
   }
@@ -108,7 +116,8 @@ public class MinecartJukebox extends MinecartBlock {
       if (disc.isEmpty()) { // no disc inserted
         // get the disc from the player, if they have one
         ItemStack handStack = player.getItemInHand(hand);
-        if (handStack.getItem() instanceof RecordItem) {
+        // In 1.21, check for JUKEBOX_PLAYABLE component instead of RecordItem
+        if (handStack.has(DataComponents.JUKEBOX_PLAYABLE)) {
           __insertRecord(handStack);
           if (!player.isCreative()) player.setItemInHand(hand, ItemStack.EMPTY);
           player.awardStat(Stats.PLAY_RECORD);
@@ -177,8 +186,16 @@ public class MinecartJukebox extends MinecartBlock {
   // clientside
   private void startPlaying () {
     if (!this.disc.isEmpty()) {
-      sound = new JukeboxCartSoundInstance(((RecordItem)this.disc.getItem()).getSound());
-      Minecraft.getInstance().getSoundManager().play(sound);
+      // In 1.21, get the sound from the JukeboxPlayable component
+      JukeboxPlayable playable = disc.get(DataComponents.JUKEBOX_PLAYABLE);
+      if (playable != null) {
+        playable.song().holder().flatMap(holder -> 
+          java.util.Optional.ofNullable(holder.value().soundEvent().value())
+        ).ifPresent(soundEvent -> {
+          sound = new JukeboxCartSoundInstance(soundEvent);
+          Minecraft.getInstance().getSoundManager().play(sound);
+        });
+      }
     }
   }
 

--- a/forge/src/main/java/com/railwayteam/railways/content/minecarts/MinecartJukebox.java
+++ b/forge/src/main/java/com/railwayteam/railways/content/minecarts/MinecartJukebox.java
@@ -93,7 +93,7 @@ public class MinecartJukebox extends MinecartBlock {
 
   @Override
   public void activateMinecart(int x, int y, int z, boolean active) {
-    if (active && !level.isClientSide) {
+    if (active && !level().isClientSide) {
       if (cooldownCount <= 0) {
         cooldownCount = COOLDOWN;
         PacketSender.updateJukeboxClientside(this, this.disc);
@@ -112,7 +112,7 @@ public class MinecartJukebox extends MinecartBlock {
     InteractionResult ret = super.interact(player, hand);
     if (ret.consumesAction()) return ret;
 
-    if (!level.isClientSide) {
+    if (!level().isClientSide) {
       if (disc.isEmpty()) { // no disc inserted
         // get the disc from the player, if they have one
         ItemStack handStack = player.getItemInHand(hand);
@@ -128,27 +128,29 @@ public class MinecartJukebox extends MinecartBlock {
         __ejectRecord();
       }
     }
-    return InteractionResult.sidedSuccess(level.isClientSide);
+    return InteractionResult.sidedSuccess(level().isClientSide);
   }
 
   @Override
   protected void readAdditionalSaveData(CompoundTag compound) {
     super.readAdditionalSaveData(compound);
     if (compound.contains("Disc", Tag.TAG_COMPOUND)) {
-      disc = ItemStack.of(compound.getCompound("Disc"));
+      // In 1.21, ItemStack.parse requires a HolderLookup.Provider
+      disc = ItemStack.parseOptional(level().registryAccess(), compound.getCompound("Disc")).orElse(ItemStack.EMPTY);
     }
   }
 
   @Override
   protected void addAdditionalSaveData(CompoundTag compound) {
     super.addAdditionalSaveData(compound);
-    compound.put("Disc", disc.save(new CompoundTag()));
+    // In 1.21, save requires a HolderLookup.Provider
+    compound.put("Disc", disc.save(level().registryAccess()));
   }
 
   // clientside
   public void insertRecord (ItemStack record) {
     __insertRecord(record);
-    if (level.isClientSide) {
+    if (level().isClientSide) {
       if (!this.disc.isEmpty()) {
         if (sound == null || sound.isStopped()) {
           startPlaying();
@@ -164,21 +166,21 @@ public class MinecartJukebox extends MinecartBlock {
       content = Blocks.JUKEBOX.defaultBlockState();
     }
     this.content = content.setValue(JukeboxBlock.HAS_RECORD, !disc.isEmpty());
-    if (!level.isClientSide) PacketSender.updateJukeboxClientside(this, this.disc);
+    if (!level().isClientSide) PacketSender.updateJukeboxClientside(this, this.disc);
   }
 
   // serverside
   private void __ejectRecord () {
-    if (level.isClientSide) return;
+    if (level().isClientSide) return;
 
     Vector3d pos = new Vector3d(
       this.position().x + 0.5d,
       this.position().y + 1d,
       this.position().z + 0.5d
     );
-    ItemEntity out = new ItemEntity(level, pos.x, pos.y, pos.z, this.disc);
+    ItemEntity out = new ItemEntity(level(), pos.x, pos.y, pos.z, this.disc);
     out.setDefaultPickUpDelay();
-    level.addFreshEntity(out);
+    level().addFreshEntity(out);
     __insertRecord(ItemStack.EMPTY);
   }
 
@@ -222,7 +224,7 @@ public class MinecartJukebox extends MinecartBlock {
   @Override
   public void destroy(@NotNull DamageSource source) {
     super.destroy(source);
-    if (!source.is(DamageTypeTags.IS_EXPLOSION) && this.level.getGameRules().getBoolean(GameRules.RULE_DOENTITYDROPS) && this.disc != null && !this.disc.isEmpty()) {
+    if (!source.is(DamageTypeTags.IS_EXPLOSION) && this.level().getGameRules().getBoolean(GameRules.RULE_DOENTITYDROPS) && this.disc != null && !this.disc.isEmpty()) {
       this.spawnAtLocation(this.disc.copy());
       this.disc = ItemStack.EMPTY;
     }

--- a/forge/src/main/java/com/railwayteam/railways/forge/mixin/MixinLootDataManager.java
+++ b/forge/src/main/java/com/railwayteam/railways/forge/mixin/MixinLootDataManager.java
@@ -4,7 +4,7 @@ import com.google.gson.JsonElement;
 import com.railwayteam.railways.compat.tracks.TrackCompatUtils;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.packs.resources.ResourceManager;
-import net.minecraft.world.level.storage.loot.LootDataManager;
+import net.minecraft.server.ReloadableServerResources;
 import net.minecraft.world.level.storage.loot.LootDataType;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
@@ -13,7 +13,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import java.util.Map;
 
-@Mixin(LootDataManager.class)
+@Mixin(ReloadableServerResources.class)
 public class MixinLootDataManager {
     @Inject(method = {
         "lambda$scheduleElementParse$4"


### PR DESCRIPTION
- RecordItem: Migrated MinecartJukebox to use JukeboxPlayable component and JukeboxSong
  - Updated getComparatorOutput() to extract from JukeboxSong.comparatorOutput()
  - Changed instanceof RecordItem checks to DataComponents.JUKEBOX_PLAYABLE
  - Updated startPlaying() to get sound events from JukeboxPlayable holder

- LootDataManager: Updated MixinLootDataManager to target ReloadableServerResources
  - Changed mixin target from LootDataManager to ReloadableServerResources class

- Ingredient (final): Refactored SoftIngredient to not extend Ingredient
  - Removed extends Ingredient (now final in MC 1.21)
  - Kept toJson() and isEmpty() methods for datagen compatibility
  - Updated documentation to explain the change

These changes resolve the three specific Minecraft API incompatibilities for 1.21.x mentioned in issue #7.