### PR TITLE
Add JourneyMap compatibility classes and interfaces (Issue11)

### DIFF
--- a/forge/src/main/java/com/railwayteam/railways/compat/journeymap/DummyRailwayMarkerHandler.java
+++ b/forge/src/main/java/com/railwayteam/railways/compat/journeymap/DummyRailwayMarkerHandler.java
@@ -1,0 +1,44 @@
+/*
+ * Steam 'n' Rails
+ * Copyright (c) 2022-2024 The Railways Team
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.railwayteam.railways.compat.journeymap;
+
+import java.util.UUID;
+
+public class DummyRailwayMarkerHandler implements IRailwayMarkerHandler {
+    static IRailwayMarkerHandler instance = new DummyRailwayMarkerHandler();
+
+    public static IRailwayMarkerHandler getInstance() {
+        return instance;
+    }
+
+    @Override
+    public void removeTrain(UUID uuid) {}
+
+    @Override
+    public void removeObsolete() {}
+
+    @Override
+    public void runUpdates() {}
+
+    @Override
+    public void registerData(UUID uuid, TrainMarkerData data) {}
+
+    @Override
+    public void reloadMarkers() {}
+}

--- a/forge/src/main/java/com/railwayteam/railways/compat/journeymap/DummyRailwayMarkerHandler.java
+++ b/forge/src/main/java/com/railwayteam/railways/compat/journeymap/DummyRailwayMarkerHandler.java
@@ -21,7 +21,7 @@ package com.railwayteam.railways.compat.journeymap;
 import java.util.UUID;
 
 public class DummyRailwayMarkerHandler implements IRailwayMarkerHandler {
-    static IRailwayMarkerHandler instance = new DummyRailwayMarkerHandler();
+    private static final IRailwayMarkerHandler instance = new DummyRailwayMarkerHandler();
 
     public static IRailwayMarkerHandler getInstance() {
         return instance;

--- a/forge/src/main/java/com/railwayteam/railways/compat/journeymap/IJourneymapPlatformEventListener.java
+++ b/forge/src/main/java/com/railwayteam/railways/compat/journeymap/IJourneymapPlatformEventListener.java
@@ -1,0 +1,23 @@
+/*
+ * Steam 'n' Rails
+ * Copyright (c) 2022-2024 The Railways Team
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.railwayteam.railways.compat.journeymap;
+
+public interface IJourneymapPlatformEventListener {
+    void register();
+}

--- a/forge/src/main/java/com/railwayteam/railways/compat/journeymap/IRailwayMarkerHandler.java
+++ b/forge/src/main/java/com/railwayteam/railways/compat/journeymap/IRailwayMarkerHandler.java
@@ -1,0 +1,43 @@
+/*
+ * Steam 'n' Rails
+ * Copyright (c) 2022-2024 The Railways Team
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.railwayteam.railways.compat.journeymap;
+
+import java.util.UUID;
+
+public interface IRailwayMarkerHandler {
+    void removeTrain(UUID uuid);
+
+    void removeObsolete();
+
+    void runUpdates();
+
+    void registerData(UUID uuid, TrainMarkerData data);
+
+    void reloadMarkers();
+
+    default void onJoinWorld() {}
+
+    default void disable() {}
+
+    default void enable() {}
+
+    default boolean isEnabled() {
+        return true;
+    }
+}

--- a/forge/src/main/java/com/railwayteam/railways/compat/journeymap/RailwayMapPlugin.java
+++ b/forge/src/main/java/com/railwayteam/railways/compat/journeymap/RailwayMapPlugin.java
@@ -1,0 +1,27 @@
+/*
+ * Steam 'n' Rails
+ * Copyright (c) 2022-2024 The Railways Team
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.railwayteam.railways.compat.journeymap;
+
+import com.railwayteam.railways.Railways;
+
+public class RailwayMapPlugin {
+    public static void load() {
+        Railways.LOGGER.info("JourneyMap compatibility stub loaded (full integration disabled)");
+    }
+}

--- a/forge/src/main/java/com/railwayteam/railways/compat/journeymap/TrainMarkerData.java
+++ b/forge/src/main/java/com/railwayteam/railways/compat/journeymap/TrainMarkerData.java
@@ -1,0 +1,58 @@
+/*
+ * Steam 'n' Rails
+ * Copyright (c) 2022-2024 The Railways Team
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.railwayteam.railways.compat.journeymap;
+
+import com.simibubi.create.content.trains.entity.Carriage;
+import com.simibubi.create.content.trains.entity.CarriageBogey;
+import com.simibubi.create.content.trains.entity.Train;
+import net.minecraft.core.BlockPos;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.phys.Vec3;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public record TrainMarkerData(String name, int carriageCount, UUID owner, String destination, ResourceKey<Level> dimension, BlockPos pos, boolean incomplete) {
+
+    public static final BlockPos ABSENT_POS = new BlockPos(1331, 0, 1331);
+
+    public static TrainMarkerData make(Train train) {
+        String name = train.name.getString();// + "NO YOU DONT";
+        int carriageCount = train.carriages.size();
+        UUID owner = train.owner;
+        String destination = Optional.ofNullable(train.navigation.destination).map(s -> s.name).orElse("Unknown/Not Present");
+
+        Carriage primary = train.carriages.get(0);
+        CarriageBogey bogey = primary.leadingBogey();
+
+        ResourceKey<Level> dimension = Level.END;
+        BlockPos pos = ABSENT_POS;
+
+        if (bogey.leading().node1 != null && bogey.leading().node2 != null) {
+            dimension = bogey.leading().node1.getLocation().dimension;
+            Vec3 vecPos = bogey.leading().getPosition(train.graph);
+
+            pos = BlockPos.containing(vecPos);
+            if (pos.equals(ABSENT_POS))
+                pos = ABSENT_POS.above();
+        }
+        return new TrainMarkerData(name, carriageCount, owner, destination, dimension, pos, pos == ABSENT_POS);
+    }
+}

--- a/forge/src/main/java/com/railwayteam/railways/compat/journeymap/TrainMarkerData.java
+++ b/forge/src/main/java/com/railwayteam/railways/compat/journeymap/TrainMarkerData.java
@@ -34,7 +34,7 @@ public record TrainMarkerData(String name, int carriageCount, UUID owner, String
     public static final BlockPos ABSENT_POS = new BlockPos(1331, 0, 1331);
 
     public static TrainMarkerData make(Train train) {
-        String name = train.name.getString();// + "NO YOU DONT";
+        String name = train.name.getString();
         int carriageCount = train.carriages.size();
         UUID owner = train.owner;
         String destination = Optional.ofNullable(train.navigation.destination).map(s -> s.name).orElse("Unknown/Not Present");

--- a/forge/src/main/java/com/railwayteam/railways/compat/journeymap/TrainMarkerData.java
+++ b/forge/src/main/java/com/railwayteam/railways/compat/journeymap/TrainMarkerData.java
@@ -42,7 +42,8 @@ public record TrainMarkerData(String name, int carriageCount, UUID owner, String
         Carriage primary = train.carriages.get(0);
         CarriageBogey bogey = primary.leadingBogey();
 
-        ResourceKey<Level> dimension = Level.END;
+        // Use null to represent an unknown or absent dimension
+        ResourceKey<Level> dimension = null;
         BlockPos pos = ABSENT_POS;
 
         if (bogey.leading().node1 != null && bogey.leading().node2 != null) {


### PR DESCRIPTION
This pull request introduces a stub implementation for JourneyMap compatibility in the Railways mod. The changes provide basic interfaces, data structures, and dummy handlers to allow the rest of the mod to compile and run without full JourneyMap integration. No actual functionality for map markers or event handling is implemented; these are placeholders for future development or to allow disabling integration cleanly.

### JourneyMap Compatibility Stub

* Added the `RailwayMapPlugin` class with a `load()` method that logs when the stub is loaded, indicating that full integration is disabled.
* Created the `IRailwayMarkerHandler` interface, defining methods for train marker management and lifecycle hooks, with default implementations for enabling/disabling and joining the world.
* Implemented the `DummyRailwayMarkerHandler` class as a no-op singleton for `IRailwayMarkerHandler`, providing empty method bodies for marker management.
* Added the `TrainMarkerData` record, which encapsulates information about a train and includes a static factory method to construct marker data from a `Train` instance.
* Defined the `IJourneymapPlatformEventListener` interface for registering platform-specific event listeners.