### PR TITLE
Fix Conductor Whistle Flag Rendering and Improve Placement Logic

### DIFF
--- a/src/generated/resources/assets/railways/blockstates/conductor_whistle.json
+++ b/src/generated/resources/assets/railways/blockstates/conductor_whistle.json
@@ -1,73 +1,276 @@
 {
   "multipart": [
     {
-      "apply": {
-        "model": "railways:block/conductor_whistle/block_pole"
-      }
+      "when": {"facing": "east"},
+      "apply": {"model": "railways:block/conductor_whistle/block_pole", "y": 0}
     },
     {
-      "when": {"color": "white"},
-      "apply": {"model": "railways:block/conductor_whistle/flag_white"}
+      "when": {"facing": "south"},
+      "apply": {"model": "railways:block/conductor_whistle/block_pole", "y": 90}
     },
     {
-      "when": {"color": "orange"},
-      "apply": {"model": "railways:block/conductor_whistle/flag_orange"}
+      "when": {"facing": "west"},
+      "apply": {"model": "railways:block/conductor_whistle/block_pole", "y": 180}
     },
     {
-      "when": {"color": "magenta"},
-      "apply": {"model": "railways:block/conductor_whistle/flag_magenta"}
+      "when": {"facing": "north"},
+      "apply": {"model": "railways:block/conductor_whistle/block_pole", "y": 270}
     },
     {
-      "when": {"color": "light_blue"},
-      "apply": {"model": "railways:block/conductor_whistle/flag_light_blue"}
+      "when": {"color": "white", "facing": "east"},
+      "apply": {"model": "railways:block/conductor_whistle/flag_white", "y": 0}
     },
     {
-      "when": {"color": "yellow"},
-      "apply": {"model": "railways:block/conductor_whistle/flag_yellow"}
+      "when": {"color": "white", "facing": "south"},
+      "apply": {"model": "railways:block/conductor_whistle/flag_white", "y": 90}
     },
     {
-      "when": {"color": "lime"},
-      "apply": {"model": "railways:block/conductor_whistle/flag_lime"}
+      "when": {"color": "white", "facing": "west"},
+      "apply": {"model": "railways:block/conductor_whistle/flag_white", "y": 180}
     },
     {
-      "when": {"color": "pink"},
-      "apply": {"model": "railways:block/conductor_whistle/flag_pink"}
+      "when": {"color": "white", "facing": "north"},
+      "apply": {"model": "railways:block/conductor_whistle/flag_white", "y": 270}
     },
     {
-      "when": {"color": "gray"},
-      "apply": {"model": "railways:block/conductor_whistle/flag_gray"}
+      "when": {"color": "orange", "facing": "east"},
+      "apply": {"model": "railways:block/conductor_whistle/flag_orange", "y": 0}
     },
     {
-      "when": {"color": "light_gray"},
-      "apply": {"model": "railways:block/conductor_whistle/flag_light_gray"}
+      "when": {"color": "orange", "facing": "south"},
+      "apply": {"model": "railways:block/conductor_whistle/flag_orange", "y": 90}
     },
     {
-      "when": {"color": "cyan"},
-      "apply": {"model": "railways:block/conductor_whistle/flag_cyan"}
+      "when": {"color": "orange", "facing": "west"},
+      "apply": {"model": "railways:block/conductor_whistle/flag_orange", "y": 180}
     },
     {
-      "when": {"color": "purple"},
-      "apply": {"model": "railways:block/conductor_whistle/flag_purple"}
+      "when": {"color": "orange", "facing": "north"},
+      "apply": {"model": "railways:block/conductor_whistle/flag_orange", "y": 270}
     },
     {
-      "when": {"color": "blue"},
-      "apply": {"model": "railways:block/conductor_whistle/flag_blue"}
+      "when": {"color": "magenta", "facing": "east"},
+      "apply": {"model": "railways:block/conductor_whistle/flag_magenta", "y": 0}
     },
     {
-      "when": {"color": "brown"},
-      "apply": {"model": "railways:block/conductor_whistle/flag_brown"}
+      "when": {"color": "magenta", "facing": "south"},
+      "apply": {"model": "railways:block/conductor_whistle/flag_magenta", "y": 90}
     },
     {
-      "when": {"color": "green"},
-      "apply": {"model": "railways:block/conductor_whistle/flag_green"}
+      "when": {"color": "magenta", "facing": "west"},
+      "apply": {"model": "railways:block/conductor_whistle/flag_magenta", "y": 180}
     },
     {
-      "when": {"color": "red"},
-      "apply": {"model": "railways:block/conductor_whistle/flag_red"}
+      "when": {"color": "magenta", "facing": "north"},
+      "apply": {"model": "railways:block/conductor_whistle/flag_magenta", "y": 270}
     },
     {
-      "when": {"color": "black"},
-      "apply": {"model": "railways:block/conductor_whistle/flag_black"}
+      "when": {"color": "light_blue", "facing": "east"},
+      "apply": {"model": "railways:block/conductor_whistle/flag_light_blue", "y": 0}
+    },
+    {
+      "when": {"color": "light_blue", "facing": "south"},
+      "apply": {"model": "railways:block/conductor_whistle/flag_light_blue", "y": 90}
+    },
+    {
+      "when": {"color": "light_blue", "facing": "west"},
+      "apply": {"model": "railways:block/conductor_whistle/flag_light_blue", "y": 180}
+    },
+    {
+      "when": {"color": "light_blue", "facing": "north"},
+      "apply": {"model": "railways:block/conductor_whistle/flag_light_blue", "y": 270}
+    },
+    {
+      "when": {"color": "yellow", "facing": "east"},
+      "apply": {"model": "railways:block/conductor_whistle/flag_yellow", "y": 0}
+    },
+    {
+      "when": {"color": "yellow", "facing": "south"},
+      "apply": {"model": "railways:block/conductor_whistle/flag_yellow", "y": 90}
+    },
+    {
+      "when": {"color": "yellow", "facing": "west"},
+      "apply": {"model": "railways:block/conductor_whistle/flag_yellow", "y": 180}
+    },
+    {
+      "when": {"color": "yellow", "facing": "north"},
+      "apply": {"model": "railways:block/conductor_whistle/flag_yellow", "y": 270}
+    },
+    {
+      "when": {"color": "lime", "facing": "east"},
+      "apply": {"model": "railways:block/conductor_whistle/flag_lime", "y": 0}
+    },
+    {
+      "when": {"color": "lime", "facing": "south"},
+      "apply": {"model": "railways:block/conductor_whistle/flag_lime", "y": 90}
+    },
+    {
+      "when": {"color": "lime", "facing": "west"},
+      "apply": {"model": "railways:block/conductor_whistle/flag_lime", "y": 180}
+    },
+    {
+      "when": {"color": "lime", "facing": "north"},
+      "apply": {"model": "railways:block/conductor_whistle/flag_lime", "y": 270}
+    },
+    {
+      "when": {"color": "pink", "facing": "east"},
+      "apply": {"model": "railways:block/conductor_whistle/flag_pink", "y": 0}
+    },
+    {
+      "when": {"color": "pink", "facing": "south"},
+      "apply": {"model": "railways:block/conductor_whistle/flag_pink", "y": 90}
+    },
+    {
+      "when": {"color": "pink", "facing": "west"},
+      "apply": {"model": "railways:block/conductor_whistle/flag_pink", "y": 180}
+    },
+    {
+      "when": {"color": "pink", "facing": "north"},
+      "apply": {"model": "railways:block/conductor_whistle/flag_pink", "y": 270}
+    },
+    {
+      "when": {"color": "gray", "facing": "east"},
+      "apply": {"model": "railways:block/conductor_whistle/flag_gray", "y": 0}
+    },
+    {
+      "when": {"color": "gray", "facing": "south"},
+      "apply": {"model": "railways:block/conductor_whistle/flag_gray", "y": 90}
+    },
+    {
+      "when": {"color": "gray", "facing": "west"},
+      "apply": {"model": "railways:block/conductor_whistle/flag_gray", "y": 180}
+    },
+    {
+      "when": {"color": "gray", "facing": "north"},
+      "apply": {"model": "railways:block/conductor_whistle/flag_gray", "y": 270}
+    },
+    {
+      "when": {"color": "light_gray", "facing": "east"},
+      "apply": {"model": "railways:block/conductor_whistle/flag_light_gray", "y": 0}
+    },
+    {
+      "when": {"color": "light_gray", "facing": "south"},
+      "apply": {"model": "railways:block/conductor_whistle/flag_light_gray", "y": 90}
+    },
+    {
+      "when": {"color": "light_gray", "facing": "west"},
+      "apply": {"model": "railways:block/conductor_whistle/flag_light_gray", "y": 180}
+    },
+    {
+      "when": {"color": "light_gray", "facing": "north"},
+      "apply": {"model": "railways:block/conductor_whistle/flag_light_gray", "y": 270}
+    },
+    {
+      "when": {"color": "cyan", "facing": "east"},
+      "apply": {"model": "railways:block/conductor_whistle/flag_cyan", "y": 0}
+    },
+    {
+      "when": {"color": "cyan", "facing": "south"},
+      "apply": {"model": "railways:block/conductor_whistle/flag_cyan", "y": 90}
+    },
+    {
+      "when": {"color": "cyan", "facing": "west"},
+      "apply": {"model": "railways:block/conductor_whistle/flag_cyan", "y": 180}
+    },
+    {
+      "when": {"color": "cyan", "facing": "north"},
+      "apply": {"model": "railways:block/conductor_whistle/flag_cyan", "y": 270}
+    },
+    {
+      "when": {"color": "purple", "facing": "east"},
+      "apply": {"model": "railways:block/conductor_whistle/flag_purple", "y": 0}
+    },
+    {
+      "when": {"color": "purple", "facing": "south"},
+      "apply": {"model": "railways:block/conductor_whistle/flag_purple", "y": 90}
+    },
+    {
+      "when": {"color": "purple", "facing": "west"},
+      "apply": {"model": "railways:block/conductor_whistle/flag_purple", "y": 180}
+    },
+    {
+      "when": {"color": "purple", "facing": "north"},
+      "apply": {"model": "railways:block/conductor_whistle/flag_purple", "y": 270}
+    },
+    {
+      "when": {"color": "blue", "facing": "east"},
+      "apply": {"model": "railways:block/conductor_whistle/flag_blue", "y": 0}
+    },
+    {
+      "when": {"color": "blue", "facing": "south"},
+      "apply": {"model": "railways:block/conductor_whistle/flag_blue", "y": 90}
+    },
+    {
+      "when": {"color": "blue", "facing": "west"},
+      "apply": {"model": "railways:block/conductor_whistle/flag_blue", "y": 180}
+    },
+    {
+      "when": {"color": "blue", "facing": "north"},
+      "apply": {"model": "railways:block/conductor_whistle/flag_blue", "y": 270}
+    },
+    {
+      "when": {"color": "brown", "facing": "east"},
+      "apply": {"model": "railways:block/conductor_whistle/flag_brown", "y": 0}
+    },
+    {
+      "when": {"color": "brown", "facing": "south"},
+      "apply": {"model": "railways:block/conductor_whistle/flag_brown", "y": 90}
+    },
+    {
+      "when": {"color": "brown", "facing": "west"},
+      "apply": {"model": "railways:block/conductor_whistle/flag_brown", "y": 180}
+    },
+    {
+      "when": {"color": "brown", "facing": "north"},
+      "apply": {"model": "railways:block/conductor_whistle/flag_brown", "y": 270}
+    },
+    {
+      "when": {"color": "green", "facing": "east"},
+      "apply": {"model": "railways:block/conductor_whistle/flag_green", "y": 0}
+    },
+    {
+      "when": {"color": "green", "facing": "south"},
+      "apply": {"model": "railways:block/conductor_whistle/flag_green", "y": 90}
+    },
+    {
+      "when": {"color": "green", "facing": "west"},
+      "apply": {"model": "railways:block/conductor_whistle/flag_green", "y": 180}
+    },
+    {
+      "when": {"color": "green", "facing": "north"},
+      "apply": {"model": "railways:block/conductor_whistle/flag_green", "y": 270}
+    },
+    {
+      "when": {"color": "red", "facing": "east"},
+      "apply": {"model": "railways:block/conductor_whistle/flag_red", "y": 0}
+    },
+    {
+      "when": {"color": "red", "facing": "south"},
+      "apply": {"model": "railways:block/conductor_whistle/flag_red", "y": 90}
+    },
+    {
+      "when": {"color": "red", "facing": "west"},
+      "apply": {"model": "railways:block/conductor_whistle/flag_red", "y": 180}
+    },
+    {
+      "when": {"color": "red", "facing": "north"},
+      "apply": {"model": "railways:block/conductor_whistle/flag_red", "y": 270}
+    },
+    {
+      "when": {"color": "black", "facing": "east"},
+      "apply": {"model": "railways:block/conductor_whistle/flag_black", "y": 0}
+    },
+    {
+      "when": {"color": "black", "facing": "south"},
+      "apply": {"model": "railways:block/conductor_whistle/flag_black", "y": 90}
+    },
+    {
+      "when": {"color": "black", "facing": "west"},
+      "apply": {"model": "railways:block/conductor_whistle/flag_black", "y": 180}
+    },
+    {
+      "when": {"color": "black", "facing": "north"},
+      "apply": {"model": "railways:block/conductor_whistle/flag_black", "y": 270}
     }
   ]
 }

--- a/src/generated/resources/assets/railways/blockstates/conductor_whistle.json
+++ b/src/generated/resources/assets/railways/blockstates/conductor_whistle.json
@@ -1,7 +1,73 @@
 {
-  "variants": {
-    "": {
-      "model": "railways:block/conductor_whistle/block_pole"
+  "multipart": [
+    {
+      "apply": {
+        "model": "railways:block/conductor_whistle/block_pole"
+      }
+    },
+    {
+      "when": {"color": "white"},
+      "apply": {"model": "railways:block/conductor_whistle/flag_white"}
+    },
+    {
+      "when": {"color": "orange"},
+      "apply": {"model": "railways:block/conductor_whistle/flag_orange"}
+    },
+    {
+      "when": {"color": "magenta"},
+      "apply": {"model": "railways:block/conductor_whistle/flag_magenta"}
+    },
+    {
+      "when": {"color": "light_blue"},
+      "apply": {"model": "railways:block/conductor_whistle/flag_light_blue"}
+    },
+    {
+      "when": {"color": "yellow"},
+      "apply": {"model": "railways:block/conductor_whistle/flag_yellow"}
+    },
+    {
+      "when": {"color": "lime"},
+      "apply": {"model": "railways:block/conductor_whistle/flag_lime"}
+    },
+    {
+      "when": {"color": "pink"},
+      "apply": {"model": "railways:block/conductor_whistle/flag_pink"}
+    },
+    {
+      "when": {"color": "gray"},
+      "apply": {"model": "railways:block/conductor_whistle/flag_gray"}
+    },
+    {
+      "when": {"color": "light_gray"},
+      "apply": {"model": "railways:block/conductor_whistle/flag_light_gray"}
+    },
+    {
+      "when": {"color": "cyan"},
+      "apply": {"model": "railways:block/conductor_whistle/flag_cyan"}
+    },
+    {
+      "when": {"color": "purple"},
+      "apply": {"model": "railways:block/conductor_whistle/flag_purple"}
+    },
+    {
+      "when": {"color": "blue"},
+      "apply": {"model": "railways:block/conductor_whistle/flag_blue"}
+    },
+    {
+      "when": {"color": "brown"},
+      "apply": {"model": "railways:block/conductor_whistle/flag_brown"}
+    },
+    {
+      "when": {"color": "green"},
+      "apply": {"model": "railways:block/conductor_whistle/flag_green"}
+    },
+    {
+      "when": {"color": "red"},
+      "apply": {"model": "railways:block/conductor_whistle/flag_red"}
+    },
+    {
+      "when": {"color": "black"},
+      "apply": {"model": "railways:block/conductor_whistle/flag_black"}
     }
-  }
+  ]
 }

--- a/src/main/java/com/railwayteam/railways/base/data/neoforge/BuilderTransformersImpl.java
+++ b/src/main/java/com/railwayteam/railways/base/data/neoforge/BuilderTransformersImpl.java
@@ -163,10 +163,47 @@ public class BuilderTransformersImpl {
     }
 
     public static <B extends ConductorWhistleFlagBlock, P> NonNullUnaryOperator<BlockBuilder<B, P>> conductorWhistleFlag() {
-        return a -> a.blockstate((c, p) -> p.getVariantBuilder(c.get())
-            .forAllStates(state -> ConfiguredModel.builder()
-                .modelFile(p.models().getExistingFile(Railways.asResource("block/conductor_whistle/block_pole")))
-                .build()));
+        return a -> a.blockstate((c, p) -> {
+            var builder = p.getMultipartBuilder(c.get());
+
+            for (Direction facing : Direction.Plane.HORIZONTAL) {
+                int rotY = switch (facing) {
+                    case EAST -> 0;
+                    case SOUTH -> 90;
+                    case WEST -> 180;
+                    case NORTH -> 270;
+                    default -> 0;
+                };
+
+                builder.part()
+                    .modelFile(p.models().getExistingFile(Railways.asResource("block/conductor_whistle/block_pole")))
+                    .rotationY(rotY)
+                    .addModel()
+                    .condition(ConductorWhistleFlagBlock.FACING, facing)
+                    .end();
+            }
+
+            for (DyeColor color : DyeColor.values()) {
+                ResourceLocation modelLoc = Railways.asResource("block/conductor_whistle/flag_" + color.getSerializedName());
+                for (Direction facing : Direction.Plane.HORIZONTAL) {
+                    int rotY = switch (facing) {
+                        case EAST -> 0;
+                        case SOUTH -> 90;
+                        case WEST -> 180;
+                        case NORTH -> 270;
+                        default -> 0;
+                    };
+
+                    builder.part()
+                        .modelFile(p.models().getExistingFile(modelLoc))
+                        .rotationY(rotY)
+                        .addModel()
+                        .condition(ConductorWhistleFlagBlock.COLOR, color)
+                        .condition(ConductorWhistleFlagBlock.FACING, facing)
+                        .end();
+                }
+            }
+        });
     }
 
     public static <B extends DieselSmokeStackBlock, P> NonNullUnaryOperator<BlockBuilder<B, P>> dieselSmokeStack() {

--- a/src/main/java/com/railwayteam/railways/content/conductor/whistle/ConductorWhistleFlagBlock.java
+++ b/src/main/java/com/railwayteam/railways/content/conductor/whistle/ConductorWhistleFlagBlock.java
@@ -22,24 +22,42 @@ import com.railwayteam.railways.registry.CRBlockEntities;
 import com.railwayteam.railways.registry.CRShapes;
 import com.simibubi.create.foundation.block.IBE;
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
 import net.minecraft.world.item.DyeColor;
+import net.minecraft.world.item.context.BlockPlaceContext;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.StateDefinition;
+import net.minecraft.world.level.block.state.properties.BlockStateProperties;
+import net.minecraft.world.level.block.state.properties.DirectionProperty;
 import net.minecraft.world.level.block.state.properties.EnumProperty;
 import net.minecraft.world.phys.shapes.CollisionContext;
 import net.minecraft.world.phys.shapes.VoxelShape;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public class ConductorWhistleFlagBlock extends Block implements IBE<ConductorWhistleFlagBlockEntity> {
     public static final EnumProperty<DyeColor> COLOR = EnumProperty.create("color", DyeColor.class);
+    public static final DirectionProperty FACING = BlockStateProperties.HORIZONTAL_FACING;
 
     public ConductorWhistleFlagBlock(Properties pProperties) {
         super(pProperties);
-        registerDefaultState(defaultBlockState().setValue(COLOR, DyeColor.RED));
+        registerDefaultState(defaultBlockState()
+                .setValue(COLOR, DyeColor.RED)
+                .setValue(FACING, Direction.NORTH));
+    }
+
+    @Override
+    public @Nullable BlockState getStateForPlacement(BlockPlaceContext context) {
+        Direction dir = context.getClickedFace();
+        if (!dir.getAxis().isHorizontal())
+            dir = context.getHorizontalDirection();
+        return defaultBlockState()
+                .setValue(COLOR, DyeColor.RED)
+                .setValue(FACING, dir);
     }
 
     @Override
@@ -65,6 +83,6 @@ public class ConductorWhistleFlagBlock extends Block implements IBE<ConductorWhi
     @Override
     protected void createBlockStateDefinition(StateDefinition.Builder<Block, BlockState> builder) {
         super.createBlockStateDefinition(builder);
-        builder.add(COLOR);
+        builder.add(COLOR, FACING);
     }
 }

--- a/src/main/java/com/railwayteam/railways/content/conductor/whistle/ConductorWhistleFlagBlock.java
+++ b/src/main/java/com/railwayteam/railways/content/conductor/whistle/ConductorWhistleFlagBlock.java
@@ -22,18 +22,24 @@ import com.railwayteam.railways.registry.CRBlockEntities;
 import com.railwayteam.railways.registry.CRShapes;
 import com.simibubi.create.foundation.block.IBE;
 import net.minecraft.core.BlockPos;
+import net.minecraft.world.item.DyeColor;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.block.state.StateDefinition;
+import net.minecraft.world.level.block.state.properties.EnumProperty;
 import net.minecraft.world.phys.shapes.CollisionContext;
 import net.minecraft.world.phys.shapes.VoxelShape;
 import org.jetbrains.annotations.NotNull;
 
 public class ConductorWhistleFlagBlock extends Block implements IBE<ConductorWhistleFlagBlockEntity> {
+    public static final EnumProperty<DyeColor> COLOR = EnumProperty.create("color", DyeColor.class);
+
     public ConductorWhistleFlagBlock(Properties pProperties) {
         super(pProperties);
+        registerDefaultState(defaultBlockState().setValue(COLOR, DyeColor.RED));
     }
 
     @Override
@@ -54,5 +60,11 @@ public class ConductorWhistleFlagBlock extends Block implements IBE<ConductorWhi
     @Override
     public @NotNull VoxelShape getShape(BlockState pState, BlockGetter pLevel, BlockPos pPos, CollisionContext pContext) {
         return CRShapes.CONDUCTOR_WHISTLE_FLAG;
+    }
+
+    @Override
+    protected void createBlockStateDefinition(StateDefinition.Builder<Block, BlockState> builder) {
+        super.createBlockStateDefinition(builder);
+        builder.add(COLOR);
     }
 }

--- a/src/main/java/com/railwayteam/railways/content/conductor/whistle/ConductorWhistleFlagBlockEntity.java
+++ b/src/main/java/com/railwayteam/railways/content/conductor/whistle/ConductorWhistleFlagBlockEntity.java
@@ -55,8 +55,12 @@ public class ConductorWhistleFlagBlockEntity extends SmartBlockEntity implements
         return ConductorWhistleItem.SPECIAL_MARKER + this.getBlockPos().toShortString();
     }
 
-    DyeColor getColor() {
+    public DyeColor getColor() {
         return color;
+    }
+
+    public void setColor(DyeColor color) {
+        this.color = color;
     }
 
     @Override

--- a/src/main/java/com/railwayteam/railways/content/conductor/whistle/ConductorWhistleFlagRenderer.java
+++ b/src/main/java/com/railwayteam/railways/content/conductor/whistle/ConductorWhistleFlagRenderer.java
@@ -19,21 +19,17 @@
 package com.railwayteam.railways.content.conductor.whistle;
 
 import com.mojang.blaze3d.vertex.PoseStack;
-import com.railwayteam.railways.registry.CRBlockPartials;
 import com.railwayteam.railways.util.CustomTrackOverlayRendering;
 import com.simibubi.create.AllPartialModels;
 import com.simibubi.create.content.trains.station.GlobalStation;
 import com.simibubi.create.content.trains.track.ITrackBlock;
 import com.simibubi.create.content.trains.track.TrackTargetingBehaviour;
 import com.simibubi.create.foundation.blockEntity.renderer.SmartBlockEntityRenderer;
-import net.createmod.catnip.render.CachedBuffers;
 import net.minecraft.client.renderer.MultiBufferSource;
-import net.minecraft.client.renderer.RenderType;
 import net.minecraft.client.renderer.blockentity.BlockEntityRendererProvider;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
 
 public class ConductorWhistleFlagRenderer extends SmartBlockEntityRenderer<ConductorWhistleFlagBlockEntity> {
@@ -45,9 +41,6 @@ public class ConductorWhistleFlagRenderer extends SmartBlockEntityRenderer<Condu
     protected void renderSafe(ConductorWhistleFlagBlockEntity te, float partialTicks, PoseStack ms, MultiBufferSource buffer, int light, int overlay) {
         super.renderSafe(te, partialTicks, ms, buffer, light, overlay);
         renderEdgePoint(te, ms, buffer, light, overlay);
-
-        CachedBuffers.partial(CRBlockPartials.CONDUCTOR_WHISTLE_FLAGS.get(te.getColor()), Blocks.AIR.defaultBlockState())
-            .renderInto(ms, buffer.getBuffer(RenderType.cutout()));
     }
 
     private void renderEdgePoint(ConductorWhistleFlagBlockEntity te, PoseStack ms, MultiBufferSource buffer,

--- a/src/main/java/com/railwayteam/railways/content/conductor/whistle/ConductorWhistleItem.java
+++ b/src/main/java/com/railwayteam/railways/content/conductor/whistle/ConductorWhistleItem.java
@@ -273,8 +273,16 @@ public class ConductorWhistleItem extends TrackTargetingBlockItem {
                 }
 
                 int preferredOffset = 1;
-                if (state.getBlock() instanceof TrackBlock trackBlock && trackBlock.getMaterial().trackType == CRTrackMaterials.CRTrackType.WIDE_GAUGE)
-                    preferredOffset = 2;
+                if (state.getBlock() instanceof TrackBlock trackBlock) {
+                    var trackType = trackBlock.getMaterial().trackType;
+                    if (trackType == CRTrackMaterials.CRTrackType.WIDE_GAUGE)
+                        preferredOffset = 2;
+                    else if (trackType == CRTrackMaterials.CRTrackType.NARROW_GAUGE)
+                        preferredOffset = 1;
+                    else
+                        // Standard (and other non-narrow) tracks: place a bit farther out
+                        preferredOffset = 2;
+                }
 
                 Direction successDirection = null;
                 int successOffset = 1;

--- a/src/main/java/com/railwayteam/railways/content/conductor/whistle/ConductorWhistleItem.java
+++ b/src/main/java/com/railwayteam/railways/content/conductor/whistle/ConductorWhistleItem.java
@@ -62,6 +62,7 @@ import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.DyeColor;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.TooltipFlag;
@@ -292,7 +293,12 @@ public class ConductorWhistleItem extends TrackTargetingBlockItem {
 
                 stationName = SPECIAL_MARKER + placePos.toShortString();
 
-                BlockState placeState = CRBlocks.CONDUCTOR_WHISTLE_FLAG.getDefaultState();
+                DyeColor color = ConductorEntity.colorFrom(stackTag.getByte("SelectedColor"));
+                if (color == null)
+                    color = DyeColor.RED;
+
+                BlockState placeState = CRBlocks.CONDUCTOR_WHISTLE_FLAG.getDefaultState()
+                    .setValue(ConductorWhistleFlagBlock.COLOR, color);
                 level.setBlock(placePos, placeState, 11);
                 CompoundTag teTag = new CompoundTag();
                 teTag.putString("Name", stationName);
@@ -323,6 +329,9 @@ public class ConductorWhistleItem extends TrackTargetingBlockItem {
                     if (flagBe.station.getEdgePoint() != null) {
                         flagBe.station.getEdgePoint().name = stationName;
                     }
+                    
+                    // Sync block entity data to client for rendering
+                    flagBe.notifyUpdate();
                 }
                 stackTag.remove("SelectedPos");
                 stackTag.remove("SelectedDirection");

--- a/src/main/java/com/railwayteam/railways/content/conductor/whistle/ConductorWhistleItem.java
+++ b/src/main/java/com/railwayteam/railways/content/conductor/whistle/ConductorWhistleItem.java
@@ -25,6 +25,7 @@ import com.railwayteam.railways.mixin.AccessorTrackTargetingBehavior;
 import com.railwayteam.railways.mixin.AccessorScheduleRuntime;
 import com.railwayteam.railways.mixin_interfaces.ICarriageConductors;
 import com.railwayteam.railways.registry.CRBlocks;
+import com.railwayteam.railways.registry.CRTrackMaterials;
 import com.railwayteam.railways.registry.CREntities;
 import com.railwayteam.railways.registry.CRSounds;
 import com.railwayteam.railways.util.TextUtils;
@@ -43,9 +44,11 @@ import com.simibubi.create.content.trains.schedule.destination.DestinationInstru
 import com.simibubi.create.content.trains.station.StationBlock;
 import com.simibubi.create.content.trains.station.StationBlockEntity;
 import com.simibubi.create.content.trains.track.ITrackBlock;
+import com.simibubi.create.content.trains.track.TrackBlock;
 import com.simibubi.create.content.trains.track.TrackBlockOutline;
 import com.simibubi.create.content.trains.track.TrackTargetingBlockItem;
 import com.simibubi.create.foundation.utility.CreateLang;
+import net.createmod.catnip.data.Pair;
 import net.minecraft.ChatFormatting;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
@@ -248,8 +251,10 @@ public class ConductorWhistleItem extends TrackTargetingBlockItem {
 
             if (state.getBlock() instanceof ITrackBlock track) {
                 Vec3 lookAngle = player.getLookAngle();
-                boolean front = track.getNearestTrackAxis(level, pos, state, lookAngle)
-                        .getSecond() == Direction.AxisDirection.POSITIVE;
+                Pair<Vec3, Direction.AxisDirection> nearestTrackAxis = track.getNearestTrackAxis(level, pos, state, lookAngle);
+                boolean front = nearestTrackAxis.getSecond() == Direction.AxisDirection.POSITIVE;
+                Vec3 axisVec = nearestTrackAxis.getFirst();
+                Direction.Axis axis = Math.abs(axisVec.x) > Math.abs(axisVec.z) ? Direction.Axis.X : Direction.Axis.Z;
 
                 stackTag.put("SelectedPos", NbtUtils.writeBlockPos(pos));
                 stackTag.putBoolean("SelectedDirection", front);
@@ -267,18 +272,58 @@ public class ConductorWhistleItem extends TrackTargetingBlockItem {
                     return InteractionResult.FAIL;
                 }
 
-                Direction[] directions = new Direction[]{Direction.NORTH, Direction.EAST, Direction.SOUTH, Direction.WEST, Direction.UP};
+                int preferredOffset = 1;
+                if (state.getBlock() instanceof TrackBlock trackBlock && trackBlock.getMaterial().trackType == CRTrackMaterials.CRTrackType.WIDE_GAUGE)
+                    preferredOffset = 2;
+
                 Direction successDirection = null;
-                for (Direction direction : directions) {
-                    BlockPos placePos = pos.relative(direction);
-                    Vec3 hitPos = new Vec3(pos.getX() + 0.5, pos.getY() + 0.5, pos.getZ() + 0.5)
-                            .add(direction.getStepX() * 0.5, direction.getStepY() * 0.5, direction.getStepZ() * 0.5);
-                    BlockPlaceContext ctx = new BlockPlaceContext(
-                            player, pContext.getHand(), stack, new BlockHitResult(hitPos, direction.getOpposite(), placePos, false)
-                    );
-                    if (level.getBlockState(placePos).canBeReplaced(ctx)) {
-                        successDirection = direction;
-                        break;
+                int successOffset = 1;
+
+                // Prefer placing on the side of the track (perpendicular to the track axis) on the player's side.
+                Direction preferredSide = null;
+                if (axis == Direction.Axis.X) {
+                    preferredSide = (player.getZ() > pos.getZ() + 0.5) ? Direction.SOUTH : Direction.NORTH;
+                } else if (axis == Direction.Axis.Z) {
+                    preferredSide = (player.getX() > pos.getX() + 0.5) ? Direction.EAST : Direction.WEST;
+                }
+
+                if (preferredSide != null) {
+                    Direction alternateSide = preferredSide.getOpposite();
+
+                    for (int offset : (preferredOffset > 1 ? new int[]{preferredOffset, 1} : new int[]{1})) {
+                        for (Direction side : new Direction[]{preferredSide, alternateSide}) {
+                            BlockPos placePos = pos.relative(side, offset);
+                            Vec3 hitPos = Vec3.atCenterOf(placePos);
+                            BlockPlaceContext ctx = new BlockPlaceContext(
+                                    player, pContext.getHand(), stack,
+                                    new BlockHitResult(hitPos, side.getOpposite(), placePos, false)
+                            );
+                            if (level.getBlockState(placePos).canBeReplaced(ctx)) {
+                                successDirection = side;
+                                successOffset = offset;
+                                break;
+                            }
+                        }
+                        if (successDirection != null)
+                            break;
+                    }
+                }
+
+                // Fallback: any adjacent space (legacy behavior)
+                if (successDirection == null) {
+                    Direction[] directions = new Direction[]{Direction.NORTH, Direction.EAST, Direction.SOUTH, Direction.WEST, Direction.UP};
+                    for (Direction direction : directions) {
+                        BlockPos placePos = pos.relative(direction);
+                        Vec3 hitPos = new Vec3(pos.getX() + 0.5, pos.getY() + 0.5, pos.getZ() + 0.5)
+                                .add(direction.getStepX() * 0.5, direction.getStepY() * 0.5, direction.getStepZ() * 0.5);
+                        BlockPlaceContext ctx = new BlockPlaceContext(
+                                player, pContext.getHand(), stack, new BlockHitResult(hitPos, direction.getOpposite(), placePos, false)
+                        );
+                        if (level.getBlockState(placePos).canBeReplaced(ctx)) {
+                            successDirection = direction;
+                            successOffset = 1;
+                            break;
+                        }
                     }
                 }
 
@@ -289,7 +334,7 @@ public class ConductorWhistleItem extends TrackTargetingBlockItem {
                     return fail(player, "no_space");
                 }
 
-                BlockPos placePos = pos.relative(successDirection);
+                BlockPos placePos = pos.relative(successDirection, successOffset);
 
                 stationName = SPECIAL_MARKER + placePos.toShortString();
 
@@ -298,6 +343,7 @@ public class ConductorWhistleItem extends TrackTargetingBlockItem {
                     color = DyeColor.RED;
 
                 BlockState placeState = CRBlocks.CONDUCTOR_WHISTLE_FLAG.getDefaultState()
+                    .setValue(ConductorWhistleFlagBlock.FACING, successDirection.getAxis().isHorizontal() ? successDirection : Direction.NORTH)
                     .setValue(ConductorWhistleFlagBlock.COLOR, color);
                 level.setBlock(placePos, placeState, 11);
                 CompoundTag teTag = new CompoundTag();


### PR DESCRIPTION
The rendering issue with the Conductor Whistle flag has been resolved, ensuring that the colored flag model appears correctly for all dye colors. Additionally, the flag placement logic has been improved to account for different track widths, resulting in cleaner placement for standard gauge tracks.

Fixes #132