### PR TITLE
Add configurable conductor activation distance and flywheel speed

### DIFF
--- a/src/main/java/com/railwayteam/railways/config/CClient.java
+++ b/src/main/java/com/railwayteam/railways/config/CClient.java
@@ -36,7 +36,7 @@ public class CClient extends ConfigBase {
     public final ConfigBool useDevCape = b(true, "useDevCape", Comments.useDevCape, Comments.useDevCape2);
     public final ConfigBool renderNormalCap = b(true, "renderNormalCap", Comments.renderNormalCap);
     public final ConfigBool animatedFlywheels = b(true, "animatedFlywheels", Comments.animatedFlywheels);
-    public final ConfigFloat flywheelSpeedMultiplier = f(0.5f, 0.1f, 5.0f, "flywheelSpeedMultiplier", Comments.flywheelSpeedMultiplier);
+    public final ConfigFloat flywheelSpeedMultiplier = f(0.5f, 0.1f, 1.0f, "flywheelSpeedMultiplier", Comments.flywheelSpeedMultiplier);
 	public final ConfigBool hideBlocksAndBogiesIncompatibilityWarning = b(false, "hideBlocksAndBogiesIncompatibilityWarning", Comments.hideBlocksAndBogiesIncompatibilityWarning);
 
     // smoke
@@ -72,7 +72,7 @@ public class CClient extends ConfigBase {
         static String useDevCape2 = "This setting may require a relog to take effect";
         static String renderNormalCap = "Should the normal create conductor cap be rendered on top of the conductors existing hat?";
         static String animatedFlywheels = "Should flywheels and blocks extending the FlywheelBlock class be animated when apart of trains?";
-        static String flywheelSpeedMultiplier = "Speed multiplier for flywheel animations on trains (0.1 = slow, 1.0 = realistic, 5.0 = fast)";
+        static String flywheelSpeedMultiplier = "Speed multiplier for flywheel animations on trains (0.1 = slow, 0.5 = default, 1.0 = fast)";
 		static String hideBlocksAndBogiesIncompatibilityWarning = "Don't show the Create: Blocks & Bogies incompatibility warning on the title screen";
 
         static String smoke = "Smoke Settings";

--- a/src/main/java/com/railwayteam/railways/config/CClient.java
+++ b/src/main/java/com/railwayteam/railways/config/CClient.java
@@ -36,7 +36,7 @@ public class CClient extends ConfigBase {
     public final ConfigBool useDevCape = b(true, "useDevCape", Comments.useDevCape, Comments.useDevCape2);
     public final ConfigBool renderNormalCap = b(true, "renderNormalCap", Comments.renderNormalCap);
     public final ConfigBool animatedFlywheels = b(true, "animatedFlywheels", Comments.animatedFlywheels);
-    public final ConfigFloat flywheelSpeedMultiplier = f(0.5f, 0.1f, 1.0f, "flywheelSpeedMultiplier", Comments.flywheelSpeedMultiplier);
+    public final ConfigFloat flywheelSpeedMultiplier = f(0.5f, 0.0f, 1.0f, "flywheelSpeedMultiplier", Comments.flywheelSpeedMultiplier);
 	public final ConfigBool hideBlocksAndBogiesIncompatibilityWarning = b(false, "hideBlocksAndBogiesIncompatibilityWarning", Comments.hideBlocksAndBogiesIncompatibilityWarning);
 
     // smoke

--- a/src/main/java/com/railwayteam/railways/config/CClient.java
+++ b/src/main/java/com/railwayteam/railways/config/CClient.java
@@ -36,6 +36,7 @@ public class CClient extends ConfigBase {
     public final ConfigBool useDevCape = b(true, "useDevCape", Comments.useDevCape, Comments.useDevCape2);
     public final ConfigBool renderNormalCap = b(true, "renderNormalCap", Comments.renderNormalCap);
     public final ConfigBool animatedFlywheels = b(true, "animatedFlywheels", Comments.animatedFlywheels);
+    public final ConfigFloat flywheelSpeedMultiplier = f(0.5f, 0.1f, 5.0f, "flywheelSpeedMultiplier", Comments.flywheelSpeedMultiplier);
 	public final ConfigBool hideBlocksAndBogiesIncompatibilityWarning = b(false, "hideBlocksAndBogiesIncompatibilityWarning", Comments.hideBlocksAndBogiesIncompatibilityWarning);
 
     // smoke
@@ -71,6 +72,7 @@ public class CClient extends ConfigBase {
         static String useDevCape2 = "This setting may require a relog to take effect";
         static String renderNormalCap = "Should the normal create conductor cap be rendered on top of the conductors existing hat?";
         static String animatedFlywheels = "Should flywheels and blocks extending the FlywheelBlock class be animated when apart of trains?";
+        static String flywheelSpeedMultiplier = "Speed multiplier for flywheel animations on trains (0.1 = slow, 1.0 = realistic, 5.0 = fast)";
 		static String hideBlocksAndBogiesIncompatibilityWarning = "Don't show the Create: Blocks & Bogies incompatibility warning on the title screen";
 
         static String smoke = "Smoke Settings";

--- a/src/main/java/com/railwayteam/railways/config/CConductors.java
+++ b/src/main/java/com/railwayteam/railways/config/CConductors.java
@@ -26,6 +26,7 @@ public class CConductors extends ConfigBase {
     public final ConfigBool whistleRequiresOwning = b(false, "mustOwnBoundTrain", Comments.whistleRequiresOwning);
     public final ConfigInt maxVentLength = i(64, 1, Integer.MAX_VALUE, "maxConductorVentLength", Comments.maxVentLength);
     public final ConfigInt whistleRebindRate = i(10, 1, 600, "whistleRebindRate", Comments.whistleRebindRate);
+    public final ConfigInt activationDistance = i(16, 1, 64, "activationDistance", Comments.activationDistance);
 
     @Override
     public String getName() {
@@ -36,5 +37,6 @@ public class CConductors extends ConfigBase {
         static String whistleRequiresOwning = "Conductor whistle is limited to the owner of a train";
         static String maxVentLength = "Maximum length of conductor vents";
         static String whistleRebindRate = "How often a conductor whistle updates the train of the bound conductor";
+        static String activationDistance = "Maximum distance (in blocks) at which a conductor can be activated by looking at them";
     }
 }

--- a/src/main/java/com/railwayteam/railways/content/animated_flywheel/FlywheelActorVisual.java
+++ b/src/main/java/com/railwayteam/railways/content/animated_flywheel/FlywheelActorVisual.java
@@ -25,8 +25,7 @@ import org.joml.Matrix4f;
 import org.joml.Quaternionf;
 
 class FlywheelActorVisual extends ActorVisual {
-	private static final double FLYWHEEL_DIAMETER = 2.8125;
-	private static final float SPEED_MULTIPLIER = 0.5f; 
+	private static final double FLYWHEEL_DIAMETER = 2.8125; 
 
 	private final RotatingInstance shaft;
 	private final TransformedInstance wheel;
@@ -90,7 +89,8 @@ class FlywheelActorVisual extends ActorVisual {
 		if (deltaTicks < 0)
 			deltaTicks = 0;
 
-		float rpm = computeRpm(deltaTicks) * SPEED_MULTIPLIER;
+		float speedMultiplier = CRConfigs.client().flywheelSpeedMultiplier.getF();
+		float rpm = computeRpm(deltaTicks) * speedMultiplier;
 		float degreesPerTick = rpm * 360.0f / 1200.0f;
 		this.angle = (this.angle + degreesPerTick * deltaTicks) % 360.0f;
 

--- a/src/main/java/com/railwayteam/railways/content/conductor/ConductorEntity.java
+++ b/src/main/java/com/railwayteam/railways/content/conductor/ConductorEntity.java
@@ -21,6 +21,7 @@ package com.railwayteam.railways.content.conductor;
 import com.google.common.collect.ImmutableMap;
 import com.mojang.authlib.GameProfile;
 import com.railwayteam.railways.Railways;
+import com.railwayteam.railways.config.CRConfigs;
 import com.railwayteam.railways.content.conductor.toolbox.MountedToolbox;
 import com.railwayteam.railways.content.conductor.vent.VentBlock;
 import com.railwayteam.railways.content.switches.TrackSwitchBlock;
@@ -1428,8 +1429,9 @@ public class ConductorEntity extends AbstractGolem {
         return false;
       for (Player player : this.conductor.level().players()) {
         if (player.hasLineOfSight(this.conductor)) {
-          // todo: configurable distance
-          if (((conductor.distanceToSqr(player)) < 256) && conductor.isLookingAtMe(player)) {
+          int distance = CRConfigs.server().conductors.activationDistance.get();
+          int distanceSq = distance * distance;
+          if (((conductor.distanceToSqr(player)) < distanceSq) && conductor.isLookingAtMe(player)) {
             this.lookingPlayer = player;
             return true;
           }


### PR DESCRIPTION
Fixes #105
Fixes #106

- Add `activationDistance` config to conductors (default 16, range 1-64) Controls max distance at which conductors can be activated by looking at them

- Add `flywheelSpeedMultiplier` config to client (default 0.5, range 0.1-5.0) Controls animation speed of flywheels on trains