### PR TITLE
Fix ClassCastException when relocating trains

### DIFF
--- a/src/main/java/com/railwayteam/railways/mixin/MixinCarriageContraptionEntity.java
+++ b/src/main/java/com/railwayteam/railways/mixin/MixinCarriageContraptionEntity.java
@@ -65,7 +65,7 @@ import java.util.Optional;
 import static com.railwayteam.railways.util.BlockPosUtils.normalize;
 
 @Mixin(value = CarriageContraptionEntity.class, remap = false)
-public abstract class MixinCarriageContraptionEntity extends OrientedContraptionEntity implements IDistanceTravelled {
+public abstract class MixinCarriageContraptionEntity extends OrientedContraptionEntity implements IDistanceTravelled, IUpdateCount {
     @Shadow private Carriage carriage;
 
     private MixinCarriageContraptionEntity(EntityType<?> type, Level world) {
@@ -75,6 +75,23 @@ public abstract class MixinCarriageContraptionEntity extends OrientedContraption
     @Unique private boolean railways$fakePlayer = false;
 
     @Unique private double railways$distanceTravelled;
+
+    @Unique private int railways$updateCount = 0;
+
+    @Override
+    public int railways$getUpdateCount() {
+        return railways$updateCount;
+    }
+
+    @Override
+    public void railways$fromParent(IUpdateCount parent) {
+        railways$updateCount = parent.railways$getUpdateCount();
+    }
+
+    @Override
+    public void railways$markUpdate() {
+        railways$updateCount++;
+    }
 
     @Inject(method = "control", at = @At("HEAD"))
     private void recordFakePlayer(BlockPos controlsLocalPos, Collection<Integer> heldControls, Player player, CallbackInfoReturnable<Boolean> cir) {

--- a/src/main/resources/railways-common.mixins.json
+++ b/src/main/resources/railways-common.mixins.json
@@ -121,7 +121,6 @@
     "client.MixinBezierConnection$SegmentAngles",
     "client.MixinBlockElement_Deserializer",
     "client.MixinBogeyBlockEntityRenderer",
-    "client.MixinCarriageContraptionEntity",
     "client.MixinCarriageContraptionEntityRenderer",
     "client.MixinCarriageContraptionInstance",
     "client.MixinCarriageContraptionVisual",


### PR DESCRIPTION
## Summary
- Move `IUpdateCount` implementation from client-only mixin to common `MixinCarriageContraptionEntity`
- Remove redundant client mixin entry from `railways-common.mixins.json`

## Problem
When using a wrench to relocate a train, the server crashes with:
```
java.lang.ClassCastException: class com.simibubi.create.content.trains.entity.CarriageContraptionEntity
cannot be cast to class com.railwayteam.railways.mixin_interfaces.IUpdateCount
```

## Root Cause
`MixinTrainRelocator.railways$rebindCarriages()` runs on the server and casts `CarriageContraptionEntity` to `IUpdateCount`. However, the `IUpdateCount` interface was only being mixed in by `client.MixinCarriageContraptionEntity`, which only loads on the client side.

## Test plan
- [x] Build compiles successfully
- [x] Tested on dedicated server - train relocation works without crash

Fixes #154