### PR TITLE
Fix duplicate DefaultAttributes crash for conductor entity (#157)

### DIFF
--- a/src/main/java/com/railwayteam/railways/registry/neoforge/CREntityAttributesImpl.java
+++ b/src/main/java/com/railwayteam/railways/registry/neoforge/CREntityAttributesImpl.java
@@ -20,15 +20,13 @@ package com.railwayteam.railways.registry.neoforge;
 
 import com.railwayteam.railways.content.conductor.ConductorEntity;
 import com.railwayteam.railways.registry.CREntities;
+import net.minecraft.world.entity.ai.attributes.DefaultAttributes;
 import net.neoforged.neoforge.event.entity.EntityAttributeCreationEvent;
 
 public class CREntityAttributesImpl {
 	public static void registerAttributes(EntityAttributeCreationEvent event) {
-		// Only register if not already registered by Registrate
-		try {
+		if (!DefaultAttributes.hasSupplier(CREntities.CONDUCTOR.get())) {
 			event.put(CREntities.CONDUCTOR.get(), ConductorEntity.createAttributes().build());
-		} catch (IllegalStateException e) {
-			// Already registered
 		}
 	}
 }


### PR DESCRIPTION
The try-catch approach doesn't work because the IllegalStateException is thrown inside NeoForge's event dispatch before it can be caught in the handler.

Use DefaultAttributes.hasSupplier() to check if attributes are already registered before calling event.put(). This makes the registration idempotent.

Fixes #157