### PR TITLE
Fix Voice Chat 2.6.11 crash and config access crash

### DIFF
--- a/src/main/java/com/railwayteam/railways/compat/tracks/TrackCompatUtils.java
+++ b/src/main/java/com/railwayteam/railways/compat/tracks/TrackCompatUtils.java
@@ -66,7 +66,7 @@ public abstract class TrackCompatUtils {
     );
 
     public static boolean anyLoaded() {
-        if (GenericTrackCompat.isDataGen() || CRConfigs.common().registerMissingTracks.get())
+        if (GenericTrackCompat.isDataGen() || CRConfigs.getRegisterMissingTracks())
             return true;
         for (String mod : TRACK_COMPAT_MODS) {
             if (Mods.valueOf(mod.toUpperCase(Locale.ROOT)).isLoaded)

--- a/src/main/java/com/railwayteam/railways/mixin/compat/voicechat/ServerMixin.java
+++ b/src/main/java/com/railwayteam/railways/mixin/compat/voicechat/ServerMixin.java
@@ -27,7 +27,6 @@ import org.spongepowered.asm.mixin.Mixin;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.phys.Vec3;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Slice;
 
 import java.util.UUID;
 
@@ -43,10 +42,7 @@ public class ServerMixin {
         }
     }
 
-    @WrapOperation(method = "processProximityPacket", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/level/ServerPlayer;getUUID()Ljava/util/UUID;"),
-        slice = @Slice(
-            from = @At(value = "INVOKE", target = "Lnet/minecraft/server/level/ServerPlayer;isCrouching()Z")
-        ))
+    @WrapOperation(method = "processProximityPacket", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/level/ServerPlayer;getUUID()Ljava/util/UUID;"))
     private UUID useConductorSpyUUID(ServerPlayer instance, Operation<UUID> original) {
         if (ConductorPossessionController.isPossessingConductor(instance)) {
             return instance.getCamera().getUUID();


### PR DESCRIPTION
## Summary
- Fix #167: Remove @Slice targeting isCrouching() (removed in Voice Chat 2.6.11)
- Fix #165: Use CRConfigs.getRegisterMissingTracks() with preload fallback

## Changes

### Voice Chat Mixin Fix (#167)
Voice Chat 2.6.11 replaced crouch_distance_multiplier with whisper_distance, removing the isCrouching() call from processProximityPacket. The mixin Slice was targeting this removed method, causing crashes on startup.

Fix: Removed the Slice annotation since there is now only one getUUID() call in the method.

### Config Access Fix (#165)
TrackCompatUtils.anyLoaded() was using direct config access which crashes if called before NeoForge config system initializes.

Fix: Use CRConfigs.getRegisterMissingTracks() which has a preload fallback.

## Testing
- [ ] Server starts with Voice Chat 2.6.11 installed
- [ ] Conductor possession works correctly with Voice Chat proximity audio