### PR TITLE
Fix slab casing rendering crash with certain slabs

### DIFF
--- a/src/main/java/com/railwayteam/railways/content/custom_tracks/casing/CasingRenderUtils.java
+++ b/src/main/java/com/railwayteam/railways/content/custom_tracks/casing/CasingRenderUtils.java
@@ -68,8 +68,9 @@ public abstract class CasingRenderUtils {
     public static PartialModel reTexture(PartialModel model, SlabBlock block) {
         Pair<PartialModel, SlabBlock> key = Pair.of(model, block);
         if (!reTexturedModels.containsKey(key)) {
-            BakedModel slabModel = Minecraft.getInstance().getModelManager().getBlockModelShaper().getBlockModel(block.defaultBlockState());
-            BakedModel texturedCasing = new SpriteCopyingBakedModel(model.get(), slabModel);
+            BlockState slabState = block.defaultBlockState();
+            BakedModel slabModel = Minecraft.getInstance().getModelManager().getBlockModelShaper().getBlockModel(slabState);
+            BakedModel texturedCasing = new SpriteCopyingBakedModel(model.get(), slabModel, slabState);
             PartialModel texturedPartial = RuntimeFakePartialModel.make(Railways.asResource("runtime_casing"), texturedCasing);
             reTexturedModels.put(key, texturedPartial);
             return texturedPartial;

--- a/src/main/java/com/railwayteam/railways/content/custom_tracks/casing/SpriteCopyingBakedModel.java
+++ b/src/main/java/com/railwayteam/railways/content/custom_tracks/casing/SpriteCopyingBakedModel.java
@@ -36,10 +36,12 @@ public class SpriteCopyingBakedModel implements BakedModel {
 
   protected final BakedModel baseModel;
   protected final BakedModel spriteSourceModel;
+  protected final BlockState spriteSourceState;
 
-  public SpriteCopyingBakedModel(BakedModel baseModel, BakedModel spriteSourceModel) {
+  public SpriteCopyingBakedModel(BakedModel baseModel, BakedModel spriteSourceModel, BlockState spriteSourceState) {
     this.baseModel = baseModel;
     this.spriteSourceModel = spriteSourceModel;
+    this.spriteSourceState = spriteSourceState;
   }
 
   @Override
@@ -47,13 +49,12 @@ public class SpriteCopyingBakedModel implements BakedModel {
     ArrayList<BakedQuad> quads = new ArrayList<>();
     TextureAtlasSprite overrideSprite = spriteSourceModel.getParticleIcon();
     BakedQuad overrideQuad = null;
-    List<BakedQuad> sourceQuads = spriteSourceModel.getQuads(pState, pSide, pRand);
+    List<BakedQuad> sourceQuads = spriteSourceModel.getQuads(spriteSourceState, pSide, pRand);
     if (!sourceQuads.isEmpty()) {
       overrideSprite = sourceQuads.get(0).getSprite();
       overrideQuad = sourceQuads.get(0);
-      //Railways.LOGGER.warn("Overridesprite: "+ overrideSprite.toString());
     } else if (pSide != null) {
-      List<BakedQuad> nullQuads = spriteSourceModel.getQuads(pState, null, pRand);
+      List<BakedQuad> nullQuads = spriteSourceModel.getQuads(spriteSourceState, null, pRand);
       if (!nullQuads.isEmpty()) {
         overrideSprite = nullQuads.get(0).getSprite();
         overrideQuad = nullQuads.get(0);


### PR DESCRIPTION
## Summary

- Fix crash when placing certain slabs (oak, spruce) on tracks as casing
- Store slab's block state when creating texture-copying model
- Use stored state instead of renderer's state (air) when querying slab model

## Problem

When rendering track casings, `SpriteCopyingBakedModel.getQuads()` passed through the renderer's block state to the slab model. Flywheel passes `air` as the state for instanced rendering, causing crashes when the slab model tries to access `SlabType` properties:

```
IllegalArgumentException: Cannot get property EnumProperty{name=type...} as it does not exist in Block{minecraft:air}
```

## Solution

Store the slab's `defaultBlockState()` when constructing `SpriteCopyingBakedModel` and use that cached state when calling `getQuads()` on the slab model, rather than the passed-in state.

## Test plan

- [ ] Place oak slab on track - should render without crash
- [ ] Place spruce slab on track - should render without crash
- [ ] Verify other slabs still work correctly
- [ ] Run train over slab-covered track

Fixes #170