### PR TITLE
Fix vent teleport when possessing conductor (#176)

### DIFF
--- a/src/main/java/com/railwayteam/railways/content/conductor/ConductorEntity.java
+++ b/src/main/java/com/railwayteam/railways/content/conductor/ConductorEntity.java
@@ -540,6 +540,8 @@ public class ConductorEntity extends AbstractGolem {
 
     //can't use ServerPlayer#setCamera here because it also teleports the player
     ((com.railwayteam.railways.mixin.conductor_possession.ServerPlayerAccessor) player).setCamera(this);
+    // Also track possession separately since vanilla camera field gets reset
+    ((ServerPlayerPossessionAccess) player).railways$setPossessedConductor(this);
     CRPackets.PACKETS.sendTo(player, new SetCameraViewPacket(this));
     resetPosition();
     // update ConductorPossessionController.setRenderPosition in #tick
@@ -549,6 +551,8 @@ public class ConductorEntity extends AbstractGolem {
   public void stopViewing(ServerPlayer player) {
     if (!level().isClientSide) {
       currentlyViewing.clear();
+      // Clear possession tracking
+      ((ServerPlayerPossessionAccess) player).railways$setPossessedConductor(null);
       ((com.railwayteam.railways.mixin.conductor_possession.ServerPlayerAccessor) player).setCamera(player);
       CRPackets.PACKETS.sendTo(player, new SetCameraViewPacket(player));
       RECENTLY_DISMOUNTED_PLAYERS.add(player);
@@ -557,11 +561,13 @@ public class ConductorEntity extends AbstractGolem {
 
   @SuppressWarnings("DuplicatedCode")
   public void onSpyInteract(BlockPos pos) {
-    BlockState state;
-    if (this.canReach(pos) && canSpyInteract((state = this.level().getBlockState(pos))) && fakePlayer != null) {
+    BlockState state = this.level().getBlockState(pos);
+
+    if (this.canReach(pos) && canSpyInteract(state) && fakePlayer != null) {
       ClipContext context = new ClipContext(this.getEyePosition(), new Vec3(pos.getX()+0.5, pos.getY()+0.5, pos.getZ()+0.5),
               ClipContext.Block.OUTLINE, ClipContext.Fluid.NONE, fakePlayer);
       BlockHitResult hitResult = this.level().clip(context);
+
       if (!pos.equals(hitResult.getBlockPos()))
         return;
       boolean canUse = state.getShape(this.level(), pos).isEmpty() || EntityUtils.handleUseEvent(fakePlayer, InteractionHand.MAIN_HAND, hitResult);

--- a/src/main/java/com/railwayteam/railways/content/conductor/ConductorPossessionController.java
+++ b/src/main/java/com/railwayteam/railways/content/conductor/ConductorPossessionController.java
@@ -38,6 +38,7 @@ import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.util.Mth;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.HitResult;
 import org.jetbrains.annotations.ApiStatus;
@@ -254,9 +255,11 @@ public class ConductorPossessionController {
                         wasUsingBefore = true;
                         HitResult hitresult = mc.hitResult;
                         if (hitresult != null && hitresult.getType() == HitResult.Type.BLOCK && mc.level != null
-                                && hitresult instanceof BlockHitResult blockHitResult
-                                && ConductorEntity.canSpyInteract(mc.level.getBlockState(blockHitResult.getBlockPos()))) {
-                            CRPackets.PACKETS.send(new SpyConductorInteractPacket(blockHitResult.getBlockPos()));
+                                && hitresult instanceof BlockHitResult blockHitResult) {
+                            BlockState lookingAt = mc.level.getBlockState(blockHitResult.getBlockPos());
+                            if (ConductorEntity.canSpyInteract(lookingAt)) {
+                                CRPackets.PACKETS.send(new SpyConductorInteractPacket(blockHitResult.getBlockPos()));
+                            }
                         }
                     }
                 } else {
@@ -313,8 +316,11 @@ public class ConductorPossessionController {
 
         if (player.level().isClientSide)
             return ClientHandler.isPlayerMountedOnCamera();
-        else
-            return ((ServerPlayer) player).getCamera() instanceof ConductorEntity;
+        else {
+            // Use our custom possession tracking instead of vanilla camera field (which gets reset)
+            ConductorEntity possessed = ((ServerPlayerPossessionAccess) player).railways$getPossessedConductor();
+            return possessed != null;
+        }
     }
 
     @Nullable
@@ -324,8 +330,10 @@ public class ConductorPossessionController {
 
         if (player.level().isClientSide)
             return ClientHandler.getPlayerMountedOnCamera();
-        else
-            return ((ServerPlayer) player).getCamera() instanceof ConductorEntity ce ? ce : null;
+        else {
+            // Use our custom possession tracking instead of vanilla camera field (which gets reset)
+            return ((ServerPlayerPossessionAccess) player).railways$getPossessedConductor();
+        }
     }
 
     @OnlyIn(Dist.CLIENT)

--- a/src/main/java/com/railwayteam/railways/content/conductor/ServerPlayerPossessionAccess.java
+++ b/src/main/java/com/railwayteam/railways/content/conductor/ServerPlayerPossessionAccess.java
@@ -1,0 +1,28 @@
+/*
+ * Steam 'n' Rails
+ * Copyright (c) 2022-2025 The Railways Team
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.railwayteam.railways.content.conductor;
+
+/**
+ * Interface to access possession state stored in ServerPlayerMixin.
+ * Used because the vanilla camera field gets reset by something we can't control.
+ */
+public interface ServerPlayerPossessionAccess {
+    ConductorEntity railways$getPossessedConductor();
+    void railways$setPossessedConductor(ConductorEntity conductor);
+}

--- a/src/main/java/com/railwayteam/railways/mixin/conductor_possession/ServerPlayerMixin.java
+++ b/src/main/java/com/railwayteam/railways/mixin/conductor_possession/ServerPlayerMixin.java
@@ -20,6 +20,7 @@ package com.railwayteam.railways.mixin.conductor_possession;
 
 import com.railwayteam.railways.content.conductor.ConductorEntity;
 import com.railwayteam.railways.content.conductor.ConductorPossessionController;
+import com.railwayteam.railways.content.conductor.ServerPlayerPossessionAccess;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.entity.Entity;
 import org.spongepowered.asm.mixin.Mixin;
@@ -28,7 +29,6 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 /**
  * Makes sure the server does not move the player viewing a camera to the camera's position
@@ -40,8 +40,22 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
  * entirely, we let it proceed but intercept absMoveTo to prevent position sync.
  */
 @Mixin(value = ServerPlayer.class, priority = 1200)
-public abstract class ServerPlayerMixin {
+public abstract class ServerPlayerMixin implements ServerPlayerPossessionAccess {
 	@Shadow public abstract Entity getCamera();
+
+	// Track possession state separately since camera field gets reset
+	@org.spongepowered.asm.mixin.Unique
+	private ConductorEntity railways$possessedConductor = null;
+
+	@org.spongepowered.asm.mixin.Unique
+	public ConductorEntity railways$getPossessedConductor() {
+		return railways$possessedConductor;
+	}
+
+	@org.spongepowered.asm.mixin.Unique
+	public void railways$setPossessedConductor(ConductorEntity conductor) {
+		this.railways$possessedConductor = conductor;
+	}
 
 	/**
 	 * Redirect the isAlive() call on the camera entity to return false if the camera is null
@@ -69,11 +83,19 @@ public abstract class ServerPlayerMixin {
 	}
 
 	/**
-	 * Still prevent setting camera to ConductorEntity through normal means,
-	 * but we handle the direct field access elsewhere.
+	 * Prevent setting camera to ConductorEntity through normal means,
+	 * AND prevent resetting camera away from ConductorEntity (e.g., when vanilla thinks it's "dead").
+	 * We handle the direct field access via ServerPlayerAccessor.
 	 */
 	@Inject(method = "setCamera", at = @At("HEAD"), cancellable = true)
 	private void railways$railways$setCamera(Entity entityToSpectate, CallbackInfo ci) {
+		Entity currentCamera = this.getCamera();
+		// Prevent resetting camera FROM conductor TO something else (vanilla tick thinks conductor is "dead")
+		if (currentCamera instanceof ConductorEntity && !(entityToSpectate instanceof ConductorEntity)) {
+			ci.cancel();
+			return;
+		}
+		// Prevent setting camera TO conductor through normal setCamera (we use accessor instead)
 		if (entityToSpectate instanceof ConductorEntity) ci.cancel();
 	}
 }


### PR DESCRIPTION
Vanilla kept resetting the camera field, breaking possession tracking. Added separate tracking that doesn't get overwritten.