### PR TITLE
Add common plate tags for mod compatibility (#163)

### DIFF
--- a/src/resources/data/railways/tags/item/internal/plates/brass_plates.json
+++ b/src/resources/data/railways/tags/item/internal/plates/brass_plates.json
@@ -1,5 +1,10 @@
 {
+  "replace": false,
   "values": [
+    {
+      "id": "#c:plates/brass",
+      "required": false
+    },
     "create:brass_sheet"
   ]
 }

--- a/src/resources/data/railways/tags/item/internal/plates/iron_plates.json
+++ b/src/resources/data/railways/tags/item/internal/plates/iron_plates.json
@@ -1,5 +1,10 @@
 {
+  "replace": false,
   "values": [
+    {
+      "id": "#c:plates/iron",
+      "required": false
+    },
     "create:iron_sheet"
   ]
 }


### PR DESCRIPTION
Include c:plates/iron and c:plates/brass tags alongside Create's sheets, matching upstream behavior for cross-mod plate support.