### PR TITLE
fix: show curve tracks in track switch ponder (#186)

### DIFF
--- a/src/main/java/com/railwayteam/railways/ponder/scenes/TrainScenes.java
+++ b/src/main/java/com/railwayteam/railways/ponder/scenes/TrainScenes.java
@@ -423,8 +423,13 @@ public class TrainScenes {
         Selection straightButton = util.select().position(straightButtonPos);
         Selection rightButton = util.select().position(rightButtonPos);
 
+        Selection leftCurve = util.select().fromTo(8, 1, 5, 11, 1, 11);
+        Selection rightCurve = util.select().fromTo(3, 1, 5, 6, 1, 11);
+
         scene.world().showSection(leftTrack, Direction.DOWN);
         scene.world().showSection(rightTrack, Direction.DOWN);
+        scene.world().showSection(leftCurve, Direction.DOWN);
+        scene.world().showSection(rightCurve, Direction.DOWN);
         for (int i = 0; i < 15; i++) {
             scene.world().showSection(util.select().position(7, 1, i), Direction.DOWN);
             if (i == 1) {


### PR DESCRIPTION
The track switch ponder was missing the curve/turn tracks (fake_tracks) that connect the switch to the left and right branches. Only the endpoints and main straight track were being shown.

Added selections to show the left curve (x:8-11, z:5-11) and right curve (x:3-6, z:5-11) regions which contain the fake_track blocks.

Note: The train rendering issue in the coupler ponder appears to be an upstream Create issue (also broken in base Create per reporter).