### PR TITLE
fix: resolve conductor remote possession desync and logout cleanup (#197)

### DIFF
--- a/src/main/java/com/railwayteam/railways/content/conductor/ConductorEntity.java
+++ b/src/main/java/com/railwayteam/railways/content/conductor/ConductorEntity.java
@@ -793,6 +793,14 @@ public class ConductorEntity extends AbstractGolem {
     }
   }
 
+  @Override
+  public void travel(Vec3 movementInput) {
+    if (!this.level().isClientSide && isPossessed()) {
+      return;
+    }
+    super.travel(movementInput);
+  }
+
   /* End possession variables */
 
   protected FrequencyListener forwardListener;

--- a/src/main/java/com/railwayteam/railways/neoforge/events/CommonEventsForge.java
+++ b/src/main/java/com/railwayteam/railways/neoforge/events/CommonEventsForge.java
@@ -19,6 +19,7 @@
 package com.railwayteam.railways.neoforge.events;
 
 import com.railwayteam.railways.content.conductor.ConductorEntity;
+import com.railwayteam.railways.content.conductor.ServerPlayerPossessionAccess;
 import com.railwayteam.railways.content.conductor.toolbox.MountedToolbox;
 import com.railwayteam.railways.mixin.AccessorToolboxBlockEntity;
 import com.railwayteam.railways.registry.neoforge.CRBlockEntitiesImpl;
@@ -50,6 +51,16 @@ public class CommonEventsForge {
 	public static void onPlayerLogin(PlayerEvent.PlayerLoggedInEvent event) {
 		if (event.getEntity() instanceof ServerPlayer player)
 			CommonEvents.onPlayerJoin(player);
+	}
+
+	@SubscribeEvent
+	public static void onPlayerLogout(PlayerEvent.PlayerLoggedOutEvent event) {
+		if (event.getEntity() instanceof ServerPlayer player) {
+			ConductorEntity conductor = ((ServerPlayerPossessionAccess) player).railways$getPossessedConductor();
+			if (conductor != null) {
+				conductor.stopViewing(player);
+			}
+		}
 	}
 
 	@SubscribeEvent

--- a/src/main/java/com/railwayteam/railways/util/packet/CameraMovePacket.java
+++ b/src/main/java/com/railwayteam/railways/util/packet/CameraMovePacket.java
@@ -25,6 +25,7 @@ import com.railwayteam.railways.multiloader.C2SPacket;
 import com.railwayteam.railways.multiloader.S2CPacket;
 import com.railwayteam.railways.registry.CRPackets;
 import net.minecraft.client.Minecraft;
+import com.railwayteam.railways.content.conductor.ServerPlayerPossessionAccess;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.protocol.game.ServerboundMovePlayerPacket;
@@ -165,7 +166,8 @@ public class CameraMovePacket implements C2SPacket, S2CPacket {
 
     @Override
     public void handle(ServerPlayer sender1) {
-        if (sender1.level().getEntity(id) instanceof ConductorEntity conductor && sender1.getCamera() == conductor) {
+        ConductorEntity possessed = ((ServerPlayerPossessionAccess) sender1).railways$getPossessedConductor();
+        if (sender1.level().getEntity(id) instanceof ConductorEntity conductor && conductor == possessed) {
             if (containsInvalidValues(move.getX(0.0), move.getY(0.0), move.getZ(0.0), move.getYRot(0.0f), move.getXRot(0.0f))) {
                 sender1.connection.disconnect(Component.translatable("multiplayer.disconnect.invalid_player_movement"));
                 return;
@@ -227,7 +229,7 @@ public class CameraMovePacket implements C2SPacket, S2CPacket {
             boolean bl3 = false;
             if (q > 0.0625) {
                 bl3 = true;
-//                Railways.LOGGER.warn("{} moved wrongly!", (Object)sender1.getName().getString());
+                teleport(sender1, conductor, conductor.getX(), conductor.getY(), conductor.getZ(), g, h);
                 return;
             }
             conductor.absMoveTo(d, e, f, g, h);


### PR DESCRIPTION
Skip server-side travel() during possession to prevent double gravity/friction, clean up possession state on player logout, use reliable possession tracking for packet auth, and resync client on movement threshold instead of silent drop.

Fixes: #197 