### PR TITLE
fix: remove duplicate conductor DefaultAttributes registration (#208)

### DIFF
--- a/src/main/java/com/railwayteam/railways/neoforge/RailwaysImpl.java
+++ b/src/main/java/com/railwayteam/railways/neoforge/RailwaysImpl.java
@@ -72,7 +72,6 @@ public class RailwaysImpl {
 	public RailwaysImpl(IEventBus modEventBus, ModContainer modContainer) {
 		bus = modEventBus;
 		CRCreativeModeTabsImpl.register(RailwaysImpl.bus);
-		// Ensure mob attributes exist even if Registrate attribute wiring is missed.
 		modEventBus.addListener(CREntityAttributesImpl::registerAttributes);
 		Railways.init();
 		CRConfigsImpl.register(modContainer);

--- a/src/main/java/com/railwayteam/railways/registry/CREntities.java
+++ b/src/main/java/com/railwayteam/railways/registry/CREntities.java
@@ -71,7 +71,6 @@ public class CREntities {
                                     .apply(SetItemCountFunction.setCount(UniformGenerator.between(0.0f, 1.0f)))
                             )
             )))
-            .attributes(ConductorEntity::createAttributes)
             .register();
 
     private static <T> NonNullConsumer<T> configure(Consumer<EntityTypeConfigurator> consumer) {

--- a/src/main/java/com/railwayteam/railways/registry/neoforge/CREntityAttributesImpl.java
+++ b/src/main/java/com/railwayteam/railways/registry/neoforge/CREntityAttributesImpl.java
@@ -25,8 +25,6 @@ import net.neoforged.neoforge.event.entity.EntityAttributeCreationEvent;
 
 public class CREntityAttributesImpl {
 	public static void registerAttributes(EntityAttributeCreationEvent event) {
-		if (!DefaultAttributes.hasSupplier(CREntities.CONDUCTOR.get())) {
-			event.put(CREntities.CONDUCTOR.get(), ConductorEntity.createAttributes().build());
-		}
+		event.put(CREntities.CONDUCTOR.get(), ConductorEntity.createAttributes().build());
 	}
 }


### PR DESCRIPTION
Remove Registrate .attributes() call and use only the manual EntityAttributeCreationEvent registration to prevent duplicate entry crash.