### PR TITLE
Fix liquid fuel system not recognizing registered fluids

### DIFF
--- a/src/main/java/com/railwayteam/railways/content/fuel/LiquidFuelManager.java
+++ b/src/main/java/com/railwayteam/railways/content/fuel/LiquidFuelManager.java
@@ -21,6 +21,7 @@ package com.railwayteam.railways.content.fuel;
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import com.railwayteam.railways.Railways;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.packs.resources.ResourceManager;
 import net.minecraft.server.packs.resources.SimpleJsonResourceReloadListener;
@@ -100,6 +101,8 @@ public class LiquidFuelManager {
             }
 
             fillFluidMap();
+            Railways.LOGGER.info("Loaded {} liquid fuel type(s) ({} fluid entries, {} tag entries)",
+                    CUSTOM_TYPE_MAP.size(), FLUID_TO_TYPE_MAP.size(), TAG_TO_TYPE_MAP.size());
         }
     }
 }

--- a/src/main/java/com/railwayteam/railways/content/fuel/LiquidFuelType.java
+++ b/src/main/java/com/railwayteam/railways/content/fuel/LiquidFuelType.java
@@ -21,7 +21,7 @@ package com.railwayteam.railways.content.fuel;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
-// no dedicated ResourceLocationException available in this mapping; rely on IllegalArgumentException from parse
+import com.railwayteam.railways.Railways;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.resources.ResourceLocation;
@@ -72,17 +72,22 @@ public class LiquidFuelType {
                                 String string = primitive.getAsString();
 
                                 if (string.startsWith("#")) {
-                                    TagKey<Fluid> tag = TagKey.create(Registries.FLUID, ResourceLocation.parse(primitive.getAsString().substring(1)));
+                                    TagKey<Fluid> tag = TagKey.create(Registries.FLUID, ResourceLocation.parse(string.substring(1)));
                                     if (tag != null) {
                                         type.fluidTags.add(() -> tag);
                                     }
                                 } else {
-                                    Fluid fluid = BuiltInRegistries.FLUID.get(ResourceLocation.parse(primitive.getAsString()));
-                                    if (fluid != null) {
+                                    ResourceLocation fluidId = ResourceLocation.parse(string);
+                                    if (BuiltInRegistries.FLUID.containsKey(fluidId)) {
+                                        Fluid fluid = BuiltInRegistries.FLUID.get(fluidId);
                                         type.fluids.add(() -> fluid);
+                                    } else {
+                                        Railways.LOGGER.warn("Liquid fuel type references unknown fluid '{}', skipping", fluidId);
                                     }
                                 }
-                            } catch (IllegalArgumentException ignored) {}
+                            } catch (IllegalArgumentException e) {
+                                Railways.LOGGER.warn("Liquid fuel type has invalid fluid entry '{}': {}", primitive.getAsString(), e.getMessage());
+                            }
                         }
                     }
                 }
@@ -92,7 +97,9 @@ public class LiquidFuelType {
 
             parseJsonPrimitive(object, "fuel_ticks", JsonPrimitive::isNumber, primitive -> type.fuelTicks = primitive.getAsInt());
             parseJsonPrimitive(object, "invalid", JsonPrimitive::isBoolean, primitive -> type.invalid = primitive.getAsBoolean());
-        } catch (Exception ignored) {}
+        } catch (Exception e) {
+            Railways.LOGGER.warn("Failed to parse liquid fuel type: {}", e.getMessage());
+        }
 
         return type;
     }


### PR DESCRIPTION
Fixes #209

## Problem

`BuiltInRegistries.FLUID.get()` returns `Fluids.EMPTY` for unknown registry keys in 1.21, never `null`. The null check in `LiquidFuelType.fromJson()` always passed, silently mapping `Fluids.EMPTY` as the fuel type instead of the actual fluid. This meant real fluids (diesel, gasoline, etc.) were never matched during fuel consumption checks.

Additionally, all parsing exceptions were silently swallowed, making it impossible to diagnose datapack issues from logs.

## Fix

- Replace `get()` + null check with `containsKey()` guard so only genuinely registered fluids are added to the fuel map
- Replace silent `catch (Exception ignored)` blocks with `Railways.LOGGER.warn()` calls
- Add a reload summary log line showing how many fuel types, fluid entries, and tag entries were loaded