### PR TITLE
Fix IndexOutOfBoundsException in SpriteCopyingBakedModel (#221)

### DIFF
--- a/src/main/java/com/railwayteam/railways/content/custom_tracks/casing/SpriteCopyingBakedModel.java
+++ b/src/main/java/com/railwayteam/railways/content/custom_tracks/casing/SpriteCopyingBakedModel.java
@@ -19,6 +19,7 @@
 package com.railwayteam.railways.content.custom_tracks.casing;
 
 import com.railwayteam.railways.Railways;
+import com.simibubi.create.foundation.model.BakedQuadHelper;
 import net.minecraft.client.renderer.block.model.BakedQuad;
 import net.minecraft.client.renderer.block.model.ItemOverrides;
 import net.minecraft.client.renderer.block.model.ItemTransforms;
@@ -64,20 +65,20 @@ public class SpriteCopyingBakedModel implements BakedModel {
       if (overrideSprite == null || overrideQuad == null) {
         Railways.LOGGER.error("No overriding sprites found for side "+(pSide==null?"null":pSide.toString())+" blockstate: "+(pState==null?"null":pState.toString()));
       }
-      quads.add(new BakedQuad(transformVertices(quad.getVertices(), quad.getSprite(), (overrideQuad!=null?overrideQuad:quad)), quad.getTintIndex(), quad.getDirection(),
-          overrideSprite != null ? overrideSprite : quad.getSprite(), true));
+      TextureAtlasSprite goalSprite = overrideQuad != null ? overrideQuad.getSprite() : quad.getSprite();
+      TextureAtlasSprite baseSprite = quad.getSprite();
+      BakedQuad newQuad = BakedQuadHelper.clone(quad);
+      int[] vertexData = newQuad.getVertices();
+      for (int vertex = 0; vertex < 4; vertex++) {
+        float u = BakedQuadHelper.getU(vertexData, vertex);
+        float v = BakedQuadHelper.getV(vertexData, vertex);
+        BakedQuadHelper.setU(vertexData, vertex, u - baseSprite.getU0() + goalSprite.getU0());
+        BakedQuadHelper.setV(vertexData, vertex, v - baseSprite.getV0() + goalSprite.getV0());
+      }
+      quads.add(new BakedQuad(vertexData, quad.getTintIndex(), quad.getDirection(),
+          overrideSprite != null ? overrideSprite : baseSprite, true));
     }
     return quads;
-  }
-
-  private int[] transformVertices(int[] baseVertices, TextureAtlasSprite baseSprite, BakedQuad uvSource) {
-    TextureAtlasSprite goalSprite = uvSource.getSprite();
-    int[] newVertices = baseVertices.clone();
-    for (int i = 0; i < baseVertices.length; i += 8) {
-      newVertices[i + 4] = Float.floatToRawIntBits(Float.intBitsToFloat(baseVertices[i + 4]) - baseSprite.getU0() + goalSprite.getU0());
-      newVertices[i + 5] = Float.floatToRawIntBits(Float.intBitsToFloat(baseVertices[i + 5]) - baseSprite.getV0() + goalSprite.getV0());
-    }
-    return newVertices;
   }
 
   @Override


### PR DESCRIPTION
Replace raw vertex array indexing with hardcoded stride of 8 and UV offsets of +4/+5 with Create's BakedQuadHelper, which handles stride and offset calculation internally. This prevents array index out of bounds when vertex data has an unexpected length.