### PR TITLE
Fix NPE in CopycatHeadstockModel with NeoContinuity

### DIFF
--- a/src/main/java/com/railwayteam/railways/content/buffer/headstock/neoforge/CopycatHeadstockModel.java
+++ b/src/main/java/com/railwayteam/railways/content/buffer/headstock/neoforge/CopycatHeadstockModel.java
@@ -158,7 +158,7 @@ public class CopycatHeadstockModel implements BakedModel {
 
     private List<BakedQuad> getCopycatExtensionQuads(@Nullable BlockState state, @Nullable Direction side, @NotNull RandomSource rand, @NotNull ModelData data, @Nullable RenderType renderType) {
         // Rubidium: see below
-        if (side != null && state.getBlock() instanceof CopycatBlock ccb && ccb.shouldFaceAlwaysRender(state, side))
+        if (side != null && state != null && state.getBlock() instanceof CopycatBlock ccb && ccb.shouldFaceAlwaysRender(state, side))
             return Collections.emptyList();
 
         BlockState material = getMaterial(data);
@@ -181,7 +181,7 @@ public class CopycatHeadstockModel implements BakedModel {
 
         // Rubidium: render side!=null versions of the base material during side==null,
         // to avoid getting culled away
-        if (side == null && state.getBlock() instanceof CopycatBlock ccb)
+        if (side == null && state != null && state.getBlock() instanceof CopycatBlock ccb)
             for (Direction nonOcclusionSide : Iterate.directions)
                 if (ccb.shouldFaceAlwaysRender(state, nonOcclusionSide))
                     croppedQuads.addAll(getCroppedQuads(state, nonOcclusionSide, rand, material, wrappedData, renderType));


### PR DESCRIPTION
Fixes #219

## Problem

`getCopycatExtensionQuads` accesses `state.getBlock()` without null-checking the `@Nullable state` parameter. During item rendering, NeoContinuity's `EmissiveBakedModel` calls the 5-arg `getQuads` with a null state, causing a `NullPointerException` when opening the creative menu or viewing items in JEI.

## Fix

Added null guards for `state` at both call sites in `getCopycatExtensionQuads` (lines 161 and 184). When state is null (item rendering), these conditions short-circuit safely, and the method falls through to `getCroppedQuads` which already handles null state correctly.

## Testing

Tested with NeoContinuity 3.0.0+0.0.1+1.21.1.neoforge on client — copycat headstock renders in inventory without crashing.