### PR TITLE
fix: conductor possession cleanup and camera compat Fix #227, #232, #233, #241

### DIFF
--- a/src/main/java/com/railwayteam/railways/content/conductor/ConductorEntity.java
+++ b/src/main/java/com/railwayteam/railways/content/conductor/ConductorEntity.java
@@ -622,6 +622,21 @@ public class ConductorEntity extends AbstractGolem {
     return this.level().isClientSide && isPossessed();
   }
 
+  @Override
+  protected void customServerAiStep() {
+    if (isPossessed()) return;
+    super.customServerAiStep();
+  }
+
+  @Override
+  public void travel(@NotNull Vec3 travelVector) {
+    if (!level().isClientSide && isPossessed()) {
+      this.setDeltaMovement(Vec3.ZERO);
+      return;
+    }
+    super.travel(travelVector);
+  }
+
   // only used by MouseHandler
   public void turnView(double yRot, double xRot) {
     float f = (float)xRot * 0.15f;
@@ -887,6 +902,10 @@ public class ConductorEntity extends AbstractGolem {
 
   @Override
   public void remove(@NotNull RemovalReason reason) {
+    if (!level().isClientSide) {
+      ServerPlayer viewer = currentlyViewing.get();
+      if (viewer != null) stopViewing(viewer);
+    }
     super.remove(reason);
     WITH_TOOLBOXES.get(this.level()).remove(this);
   }
@@ -1179,6 +1198,10 @@ public class ConductorEntity extends AbstractGolem {
 
   @Override
   public void die(@NotNull DamageSource pSource) {
+    if (!level().isClientSide) {
+      ServerPlayer viewer = currentlyViewing.get();
+      if (viewer != null) stopViewing(viewer);
+    }
     super.die(pSource);
     Job job = getJob();
     ItemStack holdingStack = this.unequipToolbox();

--- a/src/main/java/com/railwayteam/railways/content/conductor/ConductorPossessionController.java
+++ b/src/main/java/com/railwayteam/railways/content/conductor/ConductorPossessionController.java
@@ -317,9 +317,13 @@ public class ConductorPossessionController {
         if (player.level().isClientSide)
             return ClientHandler.isPlayerMountedOnCamera();
         else {
-            // Use our custom possession tracking instead of vanilla camera field (which gets reset)
             ConductorEntity possessed = ((ServerPlayerPossessionAccess) player).railways$getPossessedConductor();
-            return possessed != null;
+            if (possessed == null) return false;
+            if (possessed.isRemoved() || !possessed.isAlive()) {
+                ((ServerPlayerPossessionAccess) player).railways$setPossessedConductor(null);
+                return false;
+            }
+            return true;
         }
     }
 
@@ -331,8 +335,13 @@ public class ConductorPossessionController {
         if (player.level().isClientSide)
             return ClientHandler.getPlayerMountedOnCamera();
         else {
-            // Use our custom possession tracking instead of vanilla camera field (which gets reset)
-            return ((ServerPlayerPossessionAccess) player).railways$getPossessedConductor();
+            ConductorEntity possessed = ((ServerPlayerPossessionAccess) player).railways$getPossessedConductor();
+            if (possessed == null) return null;
+            if (possessed.isRemoved() || !possessed.isAlive()) {
+                ((ServerPlayerPossessionAccess) player).railways$setPossessedConductor(null);
+                return null;
+            }
+            return possessed;
         }
     }
 

--- a/src/main/java/com/railwayteam/railways/mixin/conductor_possession/ChunkMapMixin.java
+++ b/src/main/java/com/railwayteam/railways/mixin/conductor_possession/ChunkMapMixin.java
@@ -37,7 +37,6 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
  * This mixin makes sure that chunks near cameras are properly sent to the player viewing it, as well as fixing block updates
  * not getting sent to chunks loaded by cameras
  *
- * Confirmed compatible with SecurityCraft
  */
 // Disabled for 1.21.1: Original mixin shadowed a removed method signature (updateChunkTracking with parameters).
 // Keeping a placeholder class (not annotated with @Mixin) to retain history; safe to delete later.

--- a/src/main/java/com/railwayteam/railways/mixin/conductor_possession/ClientChunkCacheMixin.java
+++ b/src/main/java/com/railwayteam/railways/mixin/conductor_possession/ClientChunkCacheMixin.java
@@ -42,7 +42,6 @@ import java.util.function.Consumer;
  * These mixins aim at implementing the camera chunk storage from CameraController into all the places
  * ClientChunkCache#storage is used
  *
- * Confirmed working with Security Craft
  */
 @Mixin(value = ClientChunkCache.class, priority = 1200)
 public abstract class ClientChunkCacheMixin {

--- a/src/main/java/com/railwayteam/railways/mixin/conductor_possession/LevelRendererMixin.java
+++ b/src/main/java/com/railwayteam/railways/mixin/conductor_possession/LevelRendererMixin.java
@@ -32,7 +32,6 @@ import org.spongepowered.asm.mixin.injection.Redirect;
  * This mixin fixes camera chunks disappearing when the player entity moves while viewing a camera (e.g. while being in a
  * minecart or falling) - modified by Slimeist to instead change the position to use the conductor position if the player is mounted on a conductor
  *
- * Confirmed to be SC compatible
  */
 @Mixin(value = LevelRenderer.class, priority = 1200)
 public class LevelRendererMixin {

--- a/src/main/java/com/railwayteam/railways/mixin/conductor_possession/MixinGameRenderer.java
+++ b/src/main/java/com/railwayteam/railways/mixin/conductor_possession/MixinGameRenderer.java
@@ -63,9 +63,6 @@ public abstract class MixinGameRenderer {
 
     @Inject(method = "checkEntityPostEffect", at = @At("RETURN"))
     private void railways$checkEntityPostEffect(Entity entity, CallbackInfo ci) {
-        if (entity instanceof ConductorEntity && CRConfigs.client().useConductorSpyShader.get()) {
-            loadEffect(ResourceLocation.withDefaultNamespace("shaders/post/scan_pincushion.json"));
-        }
     }
 
     @Inject(method = "shouldRenderBlockOutline", at = @At("HEAD"), cancellable = true)

--- a/src/main/java/com/railwayteam/railways/mixin/conductor_possession/PlayerListMixin.java
+++ b/src/main/java/com/railwayteam/railways/mixin/conductor_possession/PlayerListMixin.java
@@ -36,7 +36,6 @@ import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
  * When a player is viewing a camera, enables sounds near the camera to be played, while sounds near the player entity are
  * suppressed
  *
- * Confirmed working with Security Craft
  */
 @Mixin(value = PlayerList.class, priority = 1200)
 public class PlayerListMixin {

--- a/src/main/java/com/railwayteam/railways/mixin/conductor_possession/ServerPlayerMixin.java
+++ b/src/main/java/com/railwayteam/railways/mixin/conductor_possession/ServerPlayerMixin.java
@@ -33,8 +33,6 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 /**
  * Makes sure the server does not move the player viewing a camera to the camera's position
  *
- * Confirmed compatible with SecurityCraft
- *
  * Updated for 1.21.1: In 1.21.1, the tick() method calls entity.isAlive() on the camera without
  * a null check. We need to ensure the camera is never null, so instead of canceling setCamera
  * entirely, we let it proceed but intercept absMoveTo to prevent position sync.
@@ -57,45 +55,33 @@ public abstract class ServerPlayerMixin implements ServerPlayerPossessionAccess 
 		this.railways$possessedConductor = conductor;
 	}
 
-	/**
-	 * Redirect the isAlive() call on the camera entity to return false if the camera is null
-	 * or if we're possessing a conductor. This prevents the absMoveTo from being called at all.
-	 * 
-	 * In 1.21.1, vanilla code structure is:
-	 *   Entity entity = this.getCamera();
-	 *   if (entity != this && entity.isAlive()) {
-	 *       this.absMoveTo(...);
-	 *   }
-	 */
 	@Redirect(method = "tick", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/Entity;isAlive()Z"), require = 0)
-	private boolean railways$redirectIsAlive(Entity entity) {
-		if (entity == null) {
-			return false;
-		}
-		// If possessing a conductor or viewing a SecurityCraft camera, return false to skip the absMoveTo
-		if (ConductorPossessionController.isPossessingConductor((ServerPlayer)(Object)this)) {
-			return false;
-		}
-		if (entity.getClass().getName().equals("net.geforcemods.securitycraft.entity.camera.SecurityCamera")) {
-			return false;
-		}
+	private boolean railways$nullGuardIsAlive(Entity entity) {
+		if (entity == null) return false;
 		return entity.isAlive();
 	}
 
-	/**
-	 * Prevent setting camera to ConductorEntity through normal means,
-	 * AND prevent resetting camera away from ConductorEntity (e.g., when vanilla thinks it's "dead").
-	 * We handle the direct field access via ServerPlayerAccessor.
-	 */
+	@com.llamalad7.mixinextras.injector.v2.WrapWithCondition(method = "tick", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/level/ServerPlayer;absMoveTo(DDDFF)V"), require = 0)
+	private boolean railways$shouldAbsMoveTo(ServerPlayer player, double x, double y, double z, float yaw, float pitch) {
+		return !ConductorPossessionController.isPossessingConductor(player);
+	}
+
 	@Inject(method = "setCamera", at = @At("HEAD"), cancellable = true)
 	private void railways$railways$setCamera(Entity entityToSpectate, CallbackInfo ci) {
+		ServerPlayer self = (ServerPlayer)(Object) this;
 		Entity currentCamera = this.getCamera();
-		// Prevent resetting camera FROM conductor TO something else (vanilla tick thinks conductor is "dead")
-		if (currentCamera instanceof ConductorEntity && !(entityToSpectate instanceof ConductorEntity)) {
+
+		if (entityToSpectate instanceof ConductorEntity) {
 			ci.cancel();
 			return;
 		}
-		// Prevent setting camera TO conductor through normal setCamera (we use accessor instead)
-		if (entityToSpectate instanceof ConductorEntity) ci.cancel();
+
+		if (currentCamera instanceof ConductorEntity conductor) {
+			if (entityToSpectate == self) {
+				ci.cancel();
+			} else {
+				conductor.stopViewing(self);
+			}
+		}
 	}
 }

--- a/src/main/java/com/railwayteam/railways/mixin/conductor_possession/TrackedEntityMixin.java
+++ b/src/main/java/com/railwayteam/railways/mixin/conductor_possession/TrackedEntityMixin.java
@@ -37,7 +37,6 @@ import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 /**
  * Lets entities get sent to the client even though they're not in range of the player
  *
- * Confirmed working with Security Craft
  */
 @Mixin(targets = "net.minecraft.server.level.ChunkMap$TrackedEntity", priority = 1200)
 public abstract class TrackedEntityMixin {

--- a/src/main/java/com/railwayteam/railways/neoforge/events/CommonEventsForge.java
+++ b/src/main/java/com/railwayteam/railways/neoforge/events/CommonEventsForge.java
@@ -19,6 +19,7 @@
 package com.railwayteam.railways.neoforge.events;
 
 import com.railwayteam.railways.content.conductor.ConductorEntity;
+import com.railwayteam.railways.content.conductor.ConductorPossessionController;
 import com.railwayteam.railways.content.conductor.toolbox.MountedToolbox;
 import com.railwayteam.railways.mixin.AccessorToolboxBlockEntity;
 import com.railwayteam.railways.registry.neoforge.CRBlockEntitiesImpl;
@@ -74,6 +75,16 @@ public class CommonEventsForge {
 		CREntities.CONDUCTOR.get(),
 		(entity, context) -> new ConductorItemHandler((ConductorEntity) entity)
 	);
+	}
+
+	@SubscribeEvent
+	public static void onGameModeChange(PlayerEvent.PlayerChangeGameModeEvent event) {
+		if (event.getEntity() instanceof ServerPlayer player) {
+			ConductorEntity conductor = ConductorPossessionController.getPossessingConductor(player);
+			if (conductor != null) {
+				conductor.stopViewing(player);
+			}
+		}
 	}
 
 	@SubscribeEvent

--- a/src/main/java/com/railwayteam/railways/util/packet/CameraMovePacket.java
+++ b/src/main/java/com/railwayteam/railways/util/packet/CameraMovePacket.java
@@ -21,6 +21,7 @@ package com.railwayteam.railways.util.packet;
 import com.google.common.primitives.Floats;
 import com.railwayteam.railways.Railways;
 import com.railwayteam.railways.content.conductor.ConductorEntity;
+import com.railwayteam.railways.content.conductor.ConductorPossessionController;
 import com.railwayteam.railways.multiloader.C2SPacket;
 import com.railwayteam.railways.multiloader.S2CPacket;
 import com.railwayteam.railways.registry.CRPackets;
@@ -165,7 +166,9 @@ public class CameraMovePacket implements C2SPacket, S2CPacket {
 
     @Override
     public void handle(ServerPlayer sender1) {
-        if (sender1.level().getEntity(id) instanceof ConductorEntity conductor && sender1.getCamera() == conductor) {
+        if (sender1.level().getEntity(id) instanceof ConductorEntity conductor
+                && ConductorPossessionController.isPossessingConductor(sender1)
+                && ConductorPossessionController.getPossessingConductor(sender1) == conductor) {
             if (containsInvalidValues(move.getX(0.0), move.getY(0.0), move.getZ(0.0), move.getYRot(0.0f), move.getXRot(0.0f))) {
                 sender1.connection.disconnect(Component.translatable("multiplayer.disconnect.invalid_player_movement"));
                 return;


### PR DESCRIPTION
- Clean up possession state on conductor death/removal
- Add staleness guard in isPossessingConductor/getPossessingConductor
- Allow other mods to change camera while viewing conductor
- Exit possession on gamemode change
- Suppress server-side AI/travel during possession to fix movement desync
- Use possession tracking for CameraMovePacket auth
- Disable broken scan_pincushion shader
- Remove stale compat comments