### PR TITLE
Fix dev cape config send on login (#235)

### DIFF
--- a/src/main/java/com/railwayteam/railways/events/ClientEvents.java
+++ b/src/main/java/com/railwayteam/railways/events/ClientEvents.java
@@ -46,7 +46,6 @@ public class ClientEvents {
         CRKeys.fixBinds();
         PhantomSpriteManager.tick(mc);
 
-        Level level = mc.level;
         MountedStorageSyncDeferral.clientTick(mc);
         MountedFuelTankSyncDeferral.clientTick(mc, (BlockEntity be, net.neoforged.neoforge.fluids.FluidStack fluid) -> {
             if (!(be instanceof com.railwayteam.railways.content.fuel.tank.FuelTankBlockEntity tank))
@@ -61,10 +60,6 @@ public class ClientEvents {
             tank.getFluidLevel().chase(fillLevel, 0.5, net.createmod.catnip.animation.LerpedFloat.Chaser.EXP);
             return true;
         });
-        long ticks = level == null ? 1 : level.getGameTime();
-        if (ticks % 40 == 0 && previousDevCapeSetting != (previousDevCapeSetting = CRConfigs.client().useDevCape.get())) {
-            CRPackets.PACKETS.send(new ConfigureDevCapeC2SPacket(previousDevCapeSetting));
-        }
 
         if (isGameActive()) {
             BogeyMenuEventsHandler.clientTick();
@@ -84,6 +79,12 @@ public class ClientEvents {
     @MultiLoaderEvent
     public static void onClientWorldLoad(Level level) {
         PhantomSpriteManager.firstRun = true;
+    }
+
+    @MultiLoaderEvent
+    public static void onClientJoinedServer(Minecraft mc) {
+        previousDevCapeSetting = CRConfigs.client().useDevCape.get();
+        CRPackets.PACKETS.send(new ConfigureDevCapeC2SPacket(previousDevCapeSetting));
     }
 
     protected static boolean isGameActive() {

--- a/src/main/java/com/railwayteam/railways/neoforge/events/ClientEventsForge.java
+++ b/src/main/java/com/railwayteam/railways/neoforge/events/ClientEventsForge.java
@@ -24,6 +24,7 @@ import com.railwayteam.railways.registry.neoforge.CRKeysImpl;
 import net.minecraft.client.Minecraft;
 import net.minecraft.world.level.Level;
 import net.neoforged.api.distmarker.Dist;
+import net.neoforged.neoforge.client.event.ClientPlayerNetworkEvent;
 import net.neoforged.neoforge.client.event.ClientTickEvent;
 import net.neoforged.neoforge.client.event.InputEvent;
 import net.neoforged.neoforge.client.event.RegisterClientReloadListenersEvent;
@@ -48,6 +49,11 @@ public class ClientEventsForge {
 	@SubscribeEvent
 	public static void onWorldLoad(LevelEvent.Load event) {
 		ClientEvents.onClientWorldLoad((Level) event.getLevel());
+	}
+
+	@SubscribeEvent
+	public static void onLoggingIn(ClientPlayerNetworkEvent.LoggingIn event) {
+		ClientEvents.onClientJoinedServer(Minecraft.getInstance());
 	}
 
 	@SubscribeEvent


### PR DESCRIPTION
## Summary

Fixes #235. The client-tick poll for the `useDevCape` config could fire before the play-phase packet channel was ready when joining a server cold (no single-player world loaded first), especially on heavy modpacks. That threw:

```
java.lang.UnsupportedOperationException: Payload railways:c2s may not be sent to the server!
```

## Change

Replace the every-40-ticks check in `ClientEvents.onClientTickStart` with a `ClientPlayerNetworkEvent.LoggingIn` handler that sends `ConfigureDevCapeC2SPacket` once per connection, when the channel is guaranteed ready.

## Test plan

- [ ] Cold launch, set `useDevCape = true`, connect directly to a server without first loading a single-player world — no crash
- [ ] Launch a single-player world, then join a server — dev cape setting syncs on connect