### PR TITLE
fix: NPE when SpriteContents.name() returns null

### DIFF
--- a/src/main/java/com/railwayteam/railways/content/custom_tracks/phantom/PhantomSpriteManager.java
+++ b/src/main/java/com/railwayteam/railways/content/custom_tracks/phantom/PhantomSpriteManager.java
@@ -45,6 +45,11 @@ public abstract class PhantomSpriteManager {
     }
 
     public static boolean register(SpriteContents sprite) {
+        if (sprite.name() == null) {
+            Railways.LOGGER.debug("Skipping registration of sprite with null name");
+            return false;
+        }
+
         if (sprite.name().getNamespace().equals(Railways.MOD_ID) && sprite.name().getPath().startsWith("block/track/phantom/")) {
             map.put(sprite.name(), new WeakReference<>(sprite));
             firstRun = true;


### PR DESCRIPTION
resolve https://github.com/Porters-of-Railways/Railway-1.21.1/issues/265

This isn't the best fix; SpriteContents.name() should never be null, but I can't find the incorrect code in the Supplementaries.