### PR TITLE
fix: update toolbox overlay mixin target for Catnip NBTHelper (#251)

### DIFF
--- a/src/main/java/com/railwayteam/railways/mixin/client/MixinToolboxHandlerClient.java
+++ b/src/main/java/com/railwayteam/railways/mixin/client/MixinToolboxHandlerClient.java
@@ -126,7 +126,7 @@ public class MixinToolboxHandlerClient {
           remap = false,
           at = @At(
                   value = "INVOKE_ASSIGN",
-                  target = "Lnet/minecraft/nbt/NbtUtils;readBlockPos(Lnet/minecraft/nbt/CompoundTag;)Lnet/minecraft/core/BlockPos;",
+                  target = "Lnet/createmod/catnip/nbt/NBTHelper;readBlockPos(Lnet/minecraft/nbt/CompoundTag;Ljava/lang/String;)Lnet/minecraft/core/BlockPos;",
                   remap = true
           )
   )


### PR DESCRIPTION
Fixes #251.

## Root cause

`MixinToolboxHandlerClient.railways$useConductorToolboxForBackground` had a stale `@At` target. It pointed at vanilla `NbtUtils.readBlockPos(CompoundTag)`, but Create 6.0.9 reads each slot's stored toolbox `BlockPos` in `renderOverlay` via Catnip's `NBTHelper.readBlockPos(CompoundTag, String)` instead. Bytecode disassembly of `ToolboxHandlerClient.renderOverlay` confirms the call site is now `net/createmod/catnip/nbt/NBTHelper.readBlockPos`.

With no matching INVOKE in the method, the injection silently never fired. Conductor toolbox slots fell through to the unmodified path, which read `BlockPos.ZERO` from a conductor's slot NBT (the slot has `EntityUUID` but no `Pos`), the distance check failed every frame, and the dim out of range texture rendered.

The "after taking an item" trigger reported in the issue is incidental: the slot was already dim before the radial menu opened, but the menu itself hides the hotbar overlay. After closing it, the persistent dim texture becomes visible and reads as a state change.

## Fix

Update the `@At` target to the Catnip `NBTHelper.readBlockPos(CompoundTag, String)` signature. The `@ModifyVariable` body is unchanged: it still substitutes the conductor's `blockPosition()` in for the read pos when a conductor is found for the currently rendered slot. The sibling `railways$grabSlot` injection on `String.valueOf(I)` already matches and is unchanged.