### PR TITLE
fix: restore vanilla spectator mode by gating sendPosition wrap on possession (#250)

### DIFF
--- a/src/main/java/com/railwayteam/railways/mixin/conductor_possession/MixinLocalPlayer.java
+++ b/src/main/java/com/railwayteam/railways/mixin/conductor_possession/MixinLocalPlayer.java
@@ -28,7 +28,7 @@ import org.spongepowered.asm.mixin.injection.At;
 @Mixin(LocalPlayer.class)
 public class MixinLocalPlayer {
     @WrapOperation(method = "sendPosition", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/player/LocalPlayer;isControlledCamera()Z"))
-    private boolean railways$isControlledCamera(LocalPlayer instance, Operation<Integer> original) {
-        return instance.isLocalPlayer() || ConductorPossessionController.isPossessingConductor(instance);
+    private boolean railways$isControlledCamera(LocalPlayer instance, Operation<Boolean> original) {
+        return ConductorPossessionController.isPossessingConductor(instance) || original.call(instance);
     }
 }


### PR DESCRIPTION
Fixes #250.

## Root cause

`MixinLocalPlayer.railways$isControlledCamera` was forcing `LocalPlayer.isControlledCamera()` to return `true` for any local player via `instance.isLocalPlayer()`, which is true unconditionally for the local player. The wrap exists to keep the client sending position packets while possessing a conductor (since `ServerPlayerMixin` cancels the server-side `absMoveTo` follow during possession), but the gate was too broad and also forced position sync during vanilla spectator mode.

With `sendPosition` firing every tick during spectate, the client kept sending its own position to the server, overwriting the server's `absMoveTo` follow of the camera entity. Net result: the player teleported to the spectated entity once, then immediately snapped back, the camera POV never engaged, and the entity-following mechanic appeared broken.

This matches the reporter's symptom in #250: "teleports the player to the entity's location but doesn't enable first-person viewing through the entity, the entity-following mechanic doesn't activate."

## Fix

Replace `instance.isLocalPlayer()` with `original.call(instance)` so vanilla `isControlledCamera()` behavior is preserved when not possessing a conductor. The wrap now only forces `true` when conductor possession is actually in flight, which is the case `ServerPlayerMixin` covers.

Also fixes a cosmetic typo in the `Operation` generic (`Integer` -> `Boolean`) to match the wrapped method's return type.

## Compatibility

The original concern raised in the issue thread about admin tools that call /spectate without changing GameType is handled correctly: the new gate is on conductor possession state, not on GameType, so /spectate from any gametype works.

`ServerPlayerMixin`'s setCamera inject and tick redirect were already gated correctly on `ConductorEntity` and `isPossessingConductor`, so they don't need changes.