### PR TITLE
fix: write buffer bind data to BLOCK_ENTITY_DATA component (#268)

### DIFF
--- a/src/main/java/com/railwayteam/railways/content/buffer/TrackBufferBlockItem.java
+++ b/src/main/java/com/railwayteam/railways/content/buffer/TrackBufferBlockItem.java
@@ -130,20 +130,16 @@ public class TrackBufferBlockItem extends TrackTargetingBlockItem {
                 return InteractionResult.FAIL;
             }
             
-            CustomData existing = stack.getOrDefault(DataComponents.CUSTOM_DATA, CustomData.EMPTY);
-            CompoundTag stackTag = existing.copyTag();
-            
-            CompoundTag oldTeTag = stackTag.getCompound("BlockEntityTag");
-            
+            CustomData existing = stack.getOrDefault(DataComponents.BLOCK_ENTITY_DATA, CustomData.EMPTY);
+            CompoundTag oldTeTag = existing.copyTag();
+
             CompoundTag teTag = new CompoundTag();
-            if (oldTeTag != null) {
-                if (oldTeTag.contains("Material", Tag.TAG_COMPOUND))
-                    //noinspection DataFlowIssue
-                    teTag.put("Material", oldTeTag.get("Material"));
-                if (oldTeTag.contains("Color", Tag.TAG_INT))
-                    //noinspection DataFlowIssue
-                    teTag.put("Color", oldTeTag.get("Color"));
-            }
+            if (oldTeTag.contains("Material", Tag.TAG_COMPOUND))
+                //noinspection DataFlowIssue
+                teTag.put("Material", oldTeTag.get("Material"));
+            if (oldTeTag.contains("Color", Tag.TAG_INT))
+                //noinspection DataFlowIssue
+                teTag.put("Color", oldTeTag.get("Color"));
             teTag.putBoolean("TargetDirection", front);
             
             BlockPos placedPos = pos.above();
@@ -161,8 +157,7 @@ public class TrackBufferBlockItem extends TrackTargetingBlockItem {
             }
             
             teTag.put("TargetTrack", NbtUtils.writeBlockPos(pos.subtract(placedPos)));
-            stackTag.put("BlockEntityTag", teTag);
-            stack.set(DataComponents.CUSTOM_DATA, CustomData.of(stackTag));
+            stack.set(DataComponents.BLOCK_ENTITY_DATA, CustomData.of(teTag));
             
             TrackShape shape = state.getValue(TrackBlock.SHAPE);
             boolean diagonal = shape == TrackShape.PD || shape == TrackShape.ND;

--- a/src/main/java/com/railwayteam/railways/content/buffer/headstock/neoforge/CopycatHeadstockModel.java
+++ b/src/main/java/com/railwayteam/railways/content/buffer/headstock/neoforge/CopycatHeadstockModel.java
@@ -283,17 +283,14 @@ public class CopycatHeadstockModel implements BakedModel {
         BlockState material = AllBlocks.COPYCAT_BASE.getDefaultState();
         UnaryOperator<TextureAtlasSprite> colorSwapper = null;
 
-        CustomData customData = stack.getOrDefault(DataComponents.CUSTOM_DATA, CustomData.EMPTY);
-        if (!customData.isEmpty()) {
-            CompoundTag tag = customData.copyTag();
-            if (tag.contains("BlockEntityTag", Tag.TAG_COMPOUND)) {
-                CompoundTag blockEntityTag = tag.getCompound("BlockEntityTag");
-                if (blockEntityTag.contains("Material", Tag.TAG_COMPOUND)) {
-                    material = NbtUtils.readBlockState(BuiltInRegistries.BLOCK.asLookup(), blockEntityTag.getCompound("Material"));
-                }
-                if (blockEntityTag.contains("Color", Tag.TAG_INT)) {
-                    colorSwapper = getSwapper(DyeColor.byId(blockEntityTag.getInt("Color")));
-                }
+        CustomData blockEntityData = stack.getOrDefault(DataComponents.BLOCK_ENTITY_DATA, CustomData.EMPTY);
+        if (!blockEntityData.isEmpty()) {
+            CompoundTag blockEntityTag = blockEntityData.copyTag();
+            if (blockEntityTag.contains("Material", Tag.TAG_COMPOUND)) {
+                material = NbtUtils.readBlockState(BuiltInRegistries.BLOCK.asLookup(), blockEntityTag.getCompound("Material"));
+            }
+            if (blockEntityTag.contains("Color", Tag.TAG_INT)) {
+                colorSwapper = getSwapper(DyeColor.byId(blockEntityTag.getInt("Color")));
             }
         }
         final BlockState finalMaterial = material;

--- a/src/main/java/com/railwayteam/railways/content/buffer/neoforge/BufferModel.java
+++ b/src/main/java/com/railwayteam/railways/content/buffer/neoforge/BufferModel.java
@@ -145,15 +145,12 @@ public class BufferModel implements BakedModel {
         UnaryOperator<TextureAtlasSprite> materialSwapper = null;
         UnaryOperator<TextureAtlasSprite> colorSwapper = null;
 
-        CompoundTag tag = stack.getOrDefault(DataComponents.CUSTOM_DATA, CustomData.EMPTY).copyTag();
-        if (tag != null && tag.contains("BlockEntityTag", Tag.TAG_COMPOUND)) {
-            CompoundTag blockEntityTag = tag.getCompound("BlockEntityTag");
-            if (blockEntityTag.contains("Material", Tag.TAG_COMPOUND)) {
-                materialSwapper = getSwapper(NbtUtils.readBlockState(BuiltInRegistries.BLOCK.asLookup(), blockEntityTag.getCompound("Material")));
-            }
-            if (blockEntityTag.contains("Color", Tag.TAG_INT)) {
-                colorSwapper = getSwapper(DyeColor.byId(blockEntityTag.getInt("Color")));
-            }
+        CompoundTag blockEntityTag = stack.getOrDefault(DataComponents.BLOCK_ENTITY_DATA, CustomData.EMPTY).copyTag();
+        if (blockEntityTag.contains("Material", Tag.TAG_COMPOUND)) {
+            materialSwapper = getSwapper(NbtUtils.readBlockState(BuiltInRegistries.BLOCK.asLookup(), blockEntityTag.getCompound("Material")));
+        }
+        if (blockEntityTag.contains("Color", Tag.TAG_INT)) {
+            colorSwapper = getSwapper(DyeColor.byId(blockEntityTag.getInt("Color")));
         }
         final UnaryOperator<TextureAtlasSprite> finalMaterialSwapper = materialSwapper;
         final UnaryOperator<TextureAtlasSprite> finalColorSwapper = colorSwapper;


### PR DESCRIPTION
Fixes #268.

## Root cause

`TrackBufferBlockItem.useOn` stored `TargetTrack` and `TargetDirection` inside a `"BlockEntityTag"` key on the item's `DataComponents.CUSTOM_DATA` component, the 1.20-style placement-data pattern. In 1.21 Mojang split that mechanism out into a dedicated `DataComponents.BLOCK_ENTITY_DATA` component, and `BlockItem.place` only applies bind data to a placed `BlockEntity` through that component. With the data stored on the wrong component the placed buffer's `TrackTargetingBehaviour.targetTrack` field stayed at `BlockPos.ZERO`, no edge point was registered on the rail graph, and trains drove straight through the buffer.

## Verification

Reproduced and traced on a Create 6.0.10 + NeoForge 21.1.228 + Railway 0.2.0-beta.2 test server. With a one-line debug print inside `useOn` the placed BE's save tag looked like:

```
{
  ...,
  TargetDirection:1b,
  TargetTrack:[I;0,0,0],          // BE field, not initialized
  components:{
    "minecraft:custom_data":{
      BlockEntityTag:{
        TargetDirection:1b,
        TargetTrack:[I;0,-1,0]    // bind data sitting unused
      }
    }
  }
}
```

After switching the write to `BLOCK_ENTITY_DATA` the placed BE's `targetTrack` picks up the correct relative offset, and a manually driven train physically stops at the buffer.

## Scope

- `TrackBufferBlockItem.useOn`: write `teTag` directly to `BLOCK_ENTITY_DATA` instead of wrapping it under `"BlockEntityTag"` in `CUSTOM_DATA`. The `stackTag` indirection was redundant once the wrapper key is gone.
- `BufferModel` and `CopycatHeadstockModel`: read held-item Material/Color from `BLOCK_ENTITY_DATA` instead of `CUSTOM_DATA`/`BlockEntityTag`, so dyed and material-variant buffers continue to render correctly on the item in hand and after drop/re-place cycles.

The dead `teTag.remove("TargetTrack")` / `teTag.remove("TargetDirection")` cleanup at the bottom of `useOn` is left as-is; it was already a no-op after `CustomData.of` (which deep-copies the tag) and is unrelated to this fix.

## Compatibility note

Existing `0.2.0-beta.2` buffer items in player inventories that carry Material/Color in the legacy `CUSTOM_DATA/BlockEntityTag` location will not have those preserved across the upgrade. Fresh buffers placed and broken on the new version will work correctly going forward. Worth a one-line mention in the changelog when this lands.