### PR TITLE
fix: mitigate NVIDIA Linux shutdown hang by force-exiting wedged client JVM (#267)

### DIFF
--- a/src/main/java/com/railwayteam/railways/RailwaysClient.java
+++ b/src/main/java/com/railwayteam/railways/RailwaysClient.java
@@ -26,6 +26,7 @@ import com.railwayteam.railways.ponder.CRPonderPlugin;
 import com.railwayteam.railways.registry.*;
 import com.railwayteam.railways.util.CustomTrackOverlayRendering;
 import com.railwayteam.railways.util.DevCapeUtils;
+import com.railwayteam.railways.util.client.ShutdownWatchdog;
 import net.createmod.ponder.foundation.PonderIndex;
 import net.minecraft.client.model.geom.ModelLayerLocation;
 import net.minecraft.client.model.geom.builders.LayerDefinition;
@@ -36,6 +37,8 @@ import java.util.function.Supplier;
 
 public class RailwaysClient {
   public static void init() {
+    ShutdownWatchdog.arm();
+
     registerModelLayer(ConductorEntityModel.LAYER_LOCATION, ConductorEntityModel::createBodyLayer);
     registerModelLayer(ConductorCapModel.LAYER_LOCATION, ConductorCapModel::createBodyLayer);
 

--- a/src/main/java/com/railwayteam/railways/config/CClient.java
+++ b/src/main/java/com/railwayteam/railways/config/CClient.java
@@ -37,6 +37,7 @@ public class CClient extends ConfigBase {
     public final ConfigBool renderNormalCap = b(true, "renderNormalCap", Comments.renderNormalCap);
     public final ConfigBool animatedFlywheels = b(true, "animatedFlywheels", Comments.animatedFlywheels);
     public final ConfigFloat flywheelSpeedMultiplier = f(0.5f, 0.0f, 1.0f, "flywheelSpeedMultiplier", Comments.flywheelSpeedMultiplier);
+    public final ConfigBool nvidiaShutdownWatchdog = b(true, "nvidiaShutdownWatchdog", Comments.nvidiaShutdownWatchdog);
 
     // smoke
     public final ConfigGroup smoke = group(1, "smoke", Comments.smoke);
@@ -72,6 +73,7 @@ public class CClient extends ConfigBase {
         static String renderNormalCap = "Should the normal create conductor cap be rendered on top of the conductors existing hat?";
         static String animatedFlywheels = "Should flywheels and blocks extending the FlywheelBlock class be animated when apart of trains?";
         static String flywheelSpeedMultiplier = "Speed multiplier for flywheel animations on trains (0.1 = slow, 0.5 = default, 1.0 = fast)";
+        static String nvidiaShutdownWatchdog = "Force-exit the game if it hangs on the NVIDIA Linux GL-teardown bug at shutdown (issue #267). Disable if a driver update fixes the hang for you";
 
         static String smoke = "Smoke Settings";
         static String oldSmoke = "Old-style Smoke Settings";

--- a/src/main/java/com/railwayteam/railways/util/client/ShutdownWatchdog.java
+++ b/src/main/java/com/railwayteam/railways/util/client/ShutdownWatchdog.java
@@ -32,7 +32,7 @@ public final class ShutdownWatchdog {
     private ShutdownWatchdog() {}
 
     public static void arm() {
-        if (TIMEOUT_SECONDS <= 0 || !CRConfigs.client().nvidiaShutdownWatchdog.get())
+        if (TIMEOUT_SECONDS <= 0)
             return;
         String os = System.getProperty("os.name", "").toLowerCase(Locale.ROOT);
         if (!os.contains("linux"))
@@ -47,6 +47,10 @@ public final class ShutdownWatchdog {
     }
 
     private static void onShutdown() {
+        if (!CRConfigs.client().nvidiaShutdownWatchdog.get()) {
+            Railways.LOGGER.info("[watchdog] disabled via config; not force-killing");
+            return;
+        }
         long pid = ProcessHandle.current().pid();
         Railways.LOGGER.info("[watchdog] shutdown started; force-killing pid {} if still alive in {}s",
             pid, TIMEOUT_SECONDS);

--- a/src/main/java/com/railwayteam/railways/util/client/ShutdownWatchdog.java
+++ b/src/main/java/com/railwayteam/railways/util/client/ShutdownWatchdog.java
@@ -19,7 +19,10 @@
 package com.railwayteam.railways.util.client;
 
 import com.railwayteam.railways.Railways;
+import com.railwayteam.railways.config.CRConfigs;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Locale;
 
 public final class ShutdownWatchdog {
@@ -29,10 +32,13 @@ public final class ShutdownWatchdog {
     private ShutdownWatchdog() {}
 
     public static void arm() {
-        if (TIMEOUT_SECONDS <= 0)
+        if (TIMEOUT_SECONDS <= 0 || !CRConfigs.client().nvidiaShutdownWatchdog.get())
             return;
         String os = System.getProperty("os.name", "").toLowerCase(Locale.ROOT);
         if (!os.contains("linux"))
+            return;
+        // The deadlock is specific to the NVIDIA proprietary driver, so only arm when it is loaded.
+        if (!Files.exists(Path.of("/proc/driver/nvidia/version")))
             return;
         Runtime.getRuntime().addShutdownHook(
             new Thread(ShutdownWatchdog::onShutdown, "Railways NVIDIA shutdown watchdog"));
@@ -45,9 +51,11 @@ public final class ShutdownWatchdog {
         Railways.LOGGER.info("[watchdog] shutdown started; force-killing pid {} if still alive in {}s",
             pid, TIMEOUT_SECONDS);
         try {
-            new ProcessBuilder("sh", "-c",
-                "sleep " + TIMEOUT_SECONDS + "; kill -0 " + pid + " 2>/dev/null && kill -9 " + pid)
-                .start();
+            // Re-check the process start time (/proc/stat field 22) before SIGKILL so a recycled PID can't be hit.
+            String readStart = "awk '{print $22}' /proc/" + pid + "/stat 2>/dev/null";
+            String script = "S=$(" + readStart + "); sleep " + TIMEOUT_SECONDS
+                + "; [ -n \"$S\" ] && [ \"$S\" = \"$(" + readStart + ")\" ] && kill -9 " + pid;
+            new ProcessBuilder("sh", "-c", script).start();
         } catch (Exception e) {
             Railways.LOGGER.error("[watchdog] failed to spawn external killer", e);
         }

--- a/src/main/java/com/railwayteam/railways/util/client/ShutdownWatchdog.java
+++ b/src/main/java/com/railwayteam/railways/util/client/ShutdownWatchdog.java
@@ -1,0 +1,55 @@
+/*
+ * Steam 'n' Rails
+ * Copyright (c) 2022-2024 The Railways Team
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.railwayteam.railways.util.client;
+
+import com.railwayteam.railways.Railways;
+
+import java.util.Locale;
+
+public final class ShutdownWatchdog {
+    private static final long TIMEOUT_SECONDS =
+        Long.getLong("railways.shutdownWatchdogSeconds", 8L);
+
+    private ShutdownWatchdog() {}
+
+    public static void arm() {
+        if (TIMEOUT_SECONDS <= 0)
+            return;
+        String os = System.getProperty("os.name", "").toLowerCase(Locale.ROOT);
+        if (!os.contains("linux"))
+            return;
+        Runtime.getRuntime().addShutdownHook(
+            new Thread(ShutdownWatchdog::onShutdown, "Railways NVIDIA shutdown watchdog"));
+        Railways.LOGGER.info("[watchdog] armed (pid={}, timeout={}s)",
+            ProcessHandle.current().pid(), TIMEOUT_SECONDS);
+    }
+
+    private static void onShutdown() {
+        long pid = ProcessHandle.current().pid();
+        Railways.LOGGER.info("[watchdog] shutdown started; force-killing pid {} if still alive in {}s",
+            pid, TIMEOUT_SECONDS);
+        try {
+            new ProcessBuilder("sh", "-c",
+                "sleep " + TIMEOUT_SECONDS + "; kill -0 " + pid + " 2>/dev/null && kill -9 " + pid)
+                .start();
+        } catch (Exception e) {
+            Railways.LOGGER.error("[watchdog] failed to spawn external killer", e);
+        }
+    }
+}


### PR DESCRIPTION
## What
Adds a client-only shutdown watchdog that force-exits the JVM if it wedges during teardown.

## Why
On Linux with the NVIDIA proprietary driver, tearing down the GL context at process exit can deadlock inside `libnvidia-glcore` / `libGLX_nvidia`: the VMThread gets stuck processing the `VM_Exit` operation, so the client never exits, holds its memory, and the launcher never returns to focus.

Reported by several users in #267 across driver branches 580.x and 595.x, on both XWayland and native Xorg. The trigger is the NVIDIA driver, not the mod (the same machine on integrated graphics does not hang), but the mod's GL state is what surfaces it.

## How
`ShutdownWatchdog.arm()` (called from `RailwaysClient.init()`) registers a shutdown hook. When shutdown begins it starts a daemon that sends `SIGKILL` to our own pid after a timeout if the process is still alive. `SIGKILL` is delivered by the kernel independently of the wedged VMThread, so it escapes the deadlock. `System.exit` / `Runtime.halt` would not help: both re-enter the same `VM_Exit` path the VMThread can no longer process.

- Linux-only (no-op elsewhere).
- Timeout defaults to 8s, overridable via `-Drailways.shutdownWatchdogSeconds` (`<= 0` disables).
- Does not fix the underlying driver bug, it just stops the process from hanging.

## Testing
Not yet verified on affected hardware (no NVIDIA GPU available on my end). Needs a reporter on a failing config to confirm the process actually exits within the timeout window.

Closes #267 once confirmed.