### PR TITLE
fix: correct phantom-track signal marker orientation (#242)

### DIFF
--- a/src/main/java/com/railwayteam/railways/content/custom_tracks/phantom/PhantomNarrowGaugeTrackBlock.java
+++ b/src/main/java/com/railwayteam/railways/content/custom_tracks/phantom/PhantomNarrowGaugeTrackBlock.java
@@ -127,8 +127,10 @@ public class PhantomNarrowGaugeTrackBlock extends TrackBlock implements Transpar
     @Override
     @OnlyIn(Dist.CLIENT)
     public <Self extends Affine<Self>> PartialModel prepareTrackOverlay(Affine<Self> affine, BlockGetter world, BlockPos pos, BlockState state, BezierTrackPointLocation bezierPoint, AxisDirection direction, RenderedTrackOverlayType type) {
-        if (bezierPoint == null && !PhantomSpriteManager.isVisible())
+        if (bezierPoint == null && !PhantomSpriteManager.isVisible()) {
+            affine.scale(0); // hide the cached overlay instance rather than leaving it at the default orientation (#242)
             return null;
+        }
         return super.prepareTrackOverlay(affine, world, pos, state, bezierPoint, direction, type);
     }
 }

--- a/src/main/java/com/railwayteam/railways/content/custom_tracks/phantom/PhantomTrackBlock.java
+++ b/src/main/java/com/railwayteam/railways/content/custom_tracks/phantom/PhantomTrackBlock.java
@@ -40,8 +40,10 @@ public class PhantomTrackBlock extends NoCollisionCustomTrackBlock implements Tr
     @Override
     @OnlyIn(Dist.CLIENT)
     public <Self extends Affine<Self>> PartialModel prepareTrackOverlay(Affine<Self> affine, BlockGetter world, BlockPos pos, BlockState state, BezierTrackPointLocation bezierPoint, AxisDirection direction, RenderedTrackOverlayType type) {
-        if (bezierPoint == null && !PhantomSpriteManager.isVisible())
+        if (bezierPoint == null && !PhantomSpriteManager.isVisible()) {
+            affine.scale(0); // hide the cached overlay instance rather than leaving it at the default orientation (#242)
             return null;
+        }
         return super.prepareTrackOverlay(affine, world, pos, state, bezierPoint, direction, type);
     }
 }

--- a/src/main/java/com/railwayteam/railways/content/custom_tracks/phantom/PhantomWideGaugeTrackBlock.java
+++ b/src/main/java/com/railwayteam/railways/content/custom_tracks/phantom/PhantomWideGaugeTrackBlock.java
@@ -52,8 +52,10 @@ public class PhantomWideGaugeTrackBlock extends TrackBlock implements Transparen
     @Override
     @OnlyIn(Dist.CLIENT)
     public <Self extends Affine<Self>> PartialModel prepareTrackOverlay(Affine<Self> affine, BlockGetter world, BlockPos pos, BlockState state, BezierTrackPointLocation bezierPoint, AxisDirection direction, RenderedTrackOverlayType type) {
-        if (bezierPoint == null && !PhantomSpriteManager.isVisible())
+        if (bezierPoint == null && !PhantomSpriteManager.isVisible()) {
+            affine.scale(0); // hide the cached overlay instance rather than leaving it at the default orientation (#242)
             return null;
+        }
         return super.prepareTrackOverlay(affine, world, pos, state, bezierPoint, direction, type);
     }
 }


### PR DESCRIPTION
Fixes #242. Signal markers placed on phantom track rendered pointing north instead of following the track direction.

## Root cause
The placed marker is drawn by Create's `SignalVisual` (the Flywheel path; `SignalRenderer` bails when visualization is supported). `SignalVisual` computes the overlay transform only once, gated by `if (overlayState != previousOverlayState)`, and ignores the return value of `prepareTrackOverlay`.

The phantom `prepareTrackOverlay` override returned `null` without applying any transform when the track wasn't being revealed (`bezierPoint == null && !PhantomSpriteManager.isVisible()`). So if the visual was built while the track was hidden, the overlay instance was left at its default (north-facing) `setIdentityTransform()` and never recomputed. Vanilla tracks always apply the transform, which is why this was phantom-specific; the placement preview was correct because it uses the immediate-mode render path.

## Fix
When hiding, zero the instance transform (`affine.scale(0)`) instead of returning without touching it. The marker is then hidden when the track isn't revealed and correctly oriented when it is, on all three phantom variants.

## Testing
Reproduced and verified in-game (Linux/NeoForge, Flywheel `indirect`): with the fix, phantom signal markers render along the track instead of north.

## Known limitation
Because `SignalVisual` caches the transform, the marker only refreshes its orientation/visibility when the visual rebuilds (e.g. chunk reload), not the instant phantom visibility toggles. That's a Create-side caching detail; a fuller fix would invalidate the signal visuals when phantom visibility changes. Out of scope here.