### PR TITLE
feat: recognize conventional c:fuel fluids as train fuel (#281)

### DIFF
--- a/src/resources/data/railways/railways_liquid_fuel/conventional_fuels.json
+++ b/src/resources/data/railways/railways_liquid_fuel/conventional_fuels.json
@@ -1,0 +1,4 @@
+{
+  "fluids": ["#c:fuel"],
+  "fuel_ticks": 500
+}


### PR DESCRIPTION
Addresses #281 (Create: Diesel Generators compat).

## Problem
With realistic fuel enabled, DG's diesel (and gasoline, biodiesel, etc.) can be poured into the fuel tank but isn't consumed, so trains crawl. Cause: the train fuel handler only burns fluids that resolve to a `LiquidFuelType`, otherwise it falls back to the fluid's furnace burn time (`getBurnTime(bucket)/40`). DG fuels have no furnace burn time, so the fallback is 0.

## Fix
Add a data-driven fuel definition mapping the conventional `#c:fuel` tag to a burn value:

```json
{ "fluids": ["#c:fuel"], "fuel_ticks": 500 }
```

DG registers its fuels under `c:fuel` (and `c:diesel`/`c:gasoline`/etc.), so this makes all of them valid train fuel in one entry. It also covers any other mod that uses the conventional tag.

## Why soft compat
No hard dependency and no mod-presence guard needed. `#c:fuel` is a conventional tag, so it's a no-op when nothing populates it and auto-active when DG (or similar) is installed.

## Value
`fuel_ticks: 500` is the lava-equivalent baseline (lava goes through the `/40` fallback to ~500). Diesel is a refined fuel, so feel free to bump this for a stronger feel. It's the one number to tune.

## Testing
Data-only change. Verified it packages into the jar and the loader reads `data/railways/railways_liquid_fuel/`. Not verified in-game with DG installed on my end (no DG in the test instance); the reporter on #281 can confirm diesel is now consumed.