### PR TITLE
fix: connect copycat headstock textures across buffer/coupling styles (#283)

### DIFF
--- a/src/main/java/com/railwayteam/railways/content/buffer/headstock/CopycatHeadstockBlock.java
+++ b/src/main/java/com/railwayteam/railways/content/buffer/headstock/CopycatHeadstockBlock.java
@@ -139,7 +139,8 @@ public class CopycatHeadstockBlock extends WaterloggedCopycatBlock implements Bl
 
         if (isOccluded(state, toState, facing.getOpposite()))
             return true;
-        if (toState.setValue(WATERLOGGED, false) == state.setValue(WATERLOGGED, false) && coord == 0)
+        // ignore STYLE so buffer/coupling variants still merge their copycat textures (#283)
+        if (toState.setValue(WATERLOGGED, false).setValue(STYLE, state.getValue(STYLE)) == state.setValue(WATERLOGGED, false) && coord == 0)
             return true;
 
         return false;


### PR DESCRIPTION
Fixes #283.

## Problem
Copycat headstocks (buffer/coupling) only merge their copycat textures with the same STYLE. Mixing styles (buffer, coupling, buffer) leaves the textures unconnected.

## Cause
`CopycatHeadstockBlock.canConnectTexturesToward` decides same-block connection with a full blockstate equality check (only WATERLOGGED is normalized). STYLE is part of the blockstate, so a BUFFER state never equals a COUPLING state and the two don't connect.

## Fix
Normalize STYLE on the neighbour before the equality check, so it still compares FACING and UPSIDE_DOWN (which should match) but ignores STYLE. The copycat material surface is the same regardless of the buffer/coupling detailing.

```java
if (toState.setValue(WATERLOGGED, false).setValue(STYLE, state.getValue(STYLE))
        == state.setValue(WATERLOGGED, false) && coord == 0)
    return true;
```

## Testing
Not verified in-game on my end. The reporter on #283 can confirm mixed buffer/coupling copycat headstocks now connect their material textures.