### PR TITLE
fix: apply data fixers to Create schematics

### DIFF
--- a/src/main/java/com/railwayteam/railways/mixin/MixinSchematicItem.java
+++ b/src/main/java/com/railwayteam/railways/mixin/MixinSchematicItem.java
@@ -1,0 +1,40 @@
+/*
+ * Steam 'n' Rails
+ * Copyright (c) 2026 The Railways Team
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.railwayteam.railways.mixin;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.railwayteam.railways.base.datafixerapi.DataFixesInternals;
+import com.simibubi.create.content.schematics.SchematicItem;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.NbtAccounter;
+import net.minecraft.util.datafix.DataFixTypes;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+import java.io.DataInput;
+
+@Mixin(SchematicItem.class)
+public class MixinSchematicItem {
+    @WrapOperation(method = "loadSchematic", at = @At(value = "INVOKE", target = "Lnet/minecraft/nbt/NbtIo;read(Ljava/io/DataInput;Lnet/minecraft/nbt/NbtAccounter;)Lnet/minecraft/nbt/CompoundTag;"))
+    private static CompoundTag datafixSchematic(DataInput input, NbtAccounter accounter, Operation<CompoundTag> original) {
+        CompoundTag tag = original.call(input, accounter);
+        return DataFixesInternals.get().updateWithAllFixers(DataFixTypes.STRUCTURE, tag);
+    }
+}

--- a/src/main/resources/railways-common.mixins.json
+++ b/src/main/resources/railways-common.mixins.json
@@ -61,6 +61,7 @@
     "MixinRollerMovementBehaviour",
     "MixinScheduleItem",
     "MixinScheduleRuntime",
+    "MixinSchematicItem",
     "MixinSeatMovementBehaviour",
     "MixinSignalBoundary",
     "MixinSignalPropagator",


### PR DESCRIPTION
Closes #288

## Problem

Steam 'n' Rails blocks load with the wrong state from schematics, reported for locometal smokeboxes in #288.

Create loads schematics raw: `SchematicItem.loadSchematic` does `NbtIo.read` then `StructureTemplate.load`, with no datafixer pass. The Railways fixers are wired into `DataFixTypes.update` (`MixinDataFixTypes`), which that path never calls. So a schematic containing a pre-`facing` locometal smokebox keeps its old `axis` property, and on load the unknown property is dropped and the block falls back to its default orientation. The `axis -> facing` conversion in `CRDataFixers` (`LocoMetalSmokeboxFacingFix`) exists for exactly this but never runs.

This is a back-port gap, not a port mistake: upstream only added the schematic-load fixer hook on 2026-02-22, after this fork diverged.

## Fix

Restore the missing hook. A `@WrapOperation` around the `NbtIo.read` call in `loadSchematic` runs the schematic NBT through `updateWithAllFixers(DataFixTypes.STRUCTURE, ...)` before `StructureTemplate.load` sees it. Adapted to this fork's `CompoundTag`-based `updateWithAllFixers` signature (upstream takes a `Dynamic`).

Back-port of upstream Layers-of-Railways/Railway@3b62b9b.

## Scope and risk

- Runs on every schematic load (client preview + server placement) but is a no-op for current content: `updateWithAllFixers` reads `Railways_DataVersion` and skips if already current.
- Only rewrites `railways:` blocks via the registered fixers. Vanilla and other-mod blocks pass through untouched.
- Covers the other version-bumped blocks too: streamlined smokestacks, mono bogeys, BOP/Blue Skies cherry compat tracks.

## Verification

Built and booted a NeoForge dedicated server with mixin export/verbose, then inspected the woven `SchematicItem`:

- `Mixing MixinSchematicItem ... into com.simibubi.create.content.schematics.SchematicItem`
- In the woven `loadSchematic`, the `NbtIo.read` call is replaced by the generated `wrapOperation$...$datafixSchematic` handler, which calls the original read then `DataFixesInternals.get().updateWithAllFixers(DataFixTypes.STRUCTURE, tag)`
- No injector warnings; data fixers register; server boots clean

This confirms the injector binds (the config uses `defaultRequire: 0`, so a mis-targeted injector would otherwise fail silently).