### PR TITLE
fix: use c: rod tags instead of dead forge: tags on TFC tracks

### DIFF
--- a/src/generated/resources/data/railways/recipe/sequenced_assembly/track_tfc_acacia.json
+++ b/src/generated/resources/data/railways/recipe/sequenced_assembly/track_tfc_acacia.json
@@ -23,10 +23,10 @@
         },
         [
           {
-            "tag": "forge:rods/wrought_iron"
+            "tag": "c:rods/wrought_iron"
           },
           {
-            "tag": "forge:rods/zinc"
+            "tag": "c:rods/zinc"
           }
         ]
       ],
@@ -44,10 +44,10 @@
         },
         [
           {
-            "tag": "forge:rods/wrought_iron"
+            "tag": "c:rods/wrought_iron"
           },
           {
-            "tag": "forge:rods/zinc"
+            "tag": "c:rods/zinc"
           }
         ]
       ],

--- a/src/generated/resources/data/railways/recipe/sequenced_assembly/track_tfc_acacia_narrow.json
+++ b/src/generated/resources/data/railways/recipe/sequenced_assembly/track_tfc_acacia_narrow.json
@@ -36,10 +36,10 @@
         },
         [
           {
-            "tag": "forge:rods/wrought_iron"
+            "tag": "c:rods/wrought_iron"
           },
           {
-            "tag": "forge:rods/zinc"
+            "tag": "c:rods/zinc"
           }
         ]
       ],

--- a/src/generated/resources/data/railways/recipe/sequenced_assembly/track_tfc_ash.json
+++ b/src/generated/resources/data/railways/recipe/sequenced_assembly/track_tfc_ash.json
@@ -23,10 +23,10 @@
         },
         [
           {
-            "tag": "forge:rods/wrought_iron"
+            "tag": "c:rods/wrought_iron"
           },
           {
-            "tag": "forge:rods/zinc"
+            "tag": "c:rods/zinc"
           }
         ]
       ],
@@ -44,10 +44,10 @@
         },
         [
           {
-            "tag": "forge:rods/wrought_iron"
+            "tag": "c:rods/wrought_iron"
           },
           {
-            "tag": "forge:rods/zinc"
+            "tag": "c:rods/zinc"
           }
         ]
       ],

--- a/src/generated/resources/data/railways/recipe/sequenced_assembly/track_tfc_ash_narrow.json
+++ b/src/generated/resources/data/railways/recipe/sequenced_assembly/track_tfc_ash_narrow.json
@@ -36,10 +36,10 @@
         },
         [
           {
-            "tag": "forge:rods/wrought_iron"
+            "tag": "c:rods/wrought_iron"
           },
           {
-            "tag": "forge:rods/zinc"
+            "tag": "c:rods/zinc"
           }
         ]
       ],

--- a/src/generated/resources/data/railways/recipe/sequenced_assembly/track_tfc_aspen.json
+++ b/src/generated/resources/data/railways/recipe/sequenced_assembly/track_tfc_aspen.json
@@ -23,10 +23,10 @@
         },
         [
           {
-            "tag": "forge:rods/wrought_iron"
+            "tag": "c:rods/wrought_iron"
           },
           {
-            "tag": "forge:rods/zinc"
+            "tag": "c:rods/zinc"
           }
         ]
       ],
@@ -44,10 +44,10 @@
         },
         [
           {
-            "tag": "forge:rods/wrought_iron"
+            "tag": "c:rods/wrought_iron"
           },
           {
-            "tag": "forge:rods/zinc"
+            "tag": "c:rods/zinc"
           }
         ]
       ],

--- a/src/generated/resources/data/railways/recipe/sequenced_assembly/track_tfc_aspen_narrow.json
+++ b/src/generated/resources/data/railways/recipe/sequenced_assembly/track_tfc_aspen_narrow.json
@@ -36,10 +36,10 @@
         },
         [
           {
-            "tag": "forge:rods/wrought_iron"
+            "tag": "c:rods/wrought_iron"
           },
           {
-            "tag": "forge:rods/zinc"
+            "tag": "c:rods/zinc"
           }
         ]
       ],

--- a/src/generated/resources/data/railways/recipe/sequenced_assembly/track_tfc_birch.json
+++ b/src/generated/resources/data/railways/recipe/sequenced_assembly/track_tfc_birch.json
@@ -23,10 +23,10 @@
         },
         [
           {
-            "tag": "forge:rods/wrought_iron"
+            "tag": "c:rods/wrought_iron"
           },
           {
-            "tag": "forge:rods/zinc"
+            "tag": "c:rods/zinc"
           }
         ]
       ],
@@ -44,10 +44,10 @@
         },
         [
           {
-            "tag": "forge:rods/wrought_iron"
+            "tag": "c:rods/wrought_iron"
           },
           {
-            "tag": "forge:rods/zinc"
+            "tag": "c:rods/zinc"
           }
         ]
       ],

--- a/src/generated/resources/data/railways/recipe/sequenced_assembly/track_tfc_birch_narrow.json
+++ b/src/generated/resources/data/railways/recipe/sequenced_assembly/track_tfc_birch_narrow.json
@@ -36,10 +36,10 @@
         },
         [
           {
-            "tag": "forge:rods/wrought_iron"
+            "tag": "c:rods/wrought_iron"
           },
           {
-            "tag": "forge:rods/zinc"
+            "tag": "c:rods/zinc"
           }
         ]
       ],

--- a/src/generated/resources/data/railways/recipe/sequenced_assembly/track_tfc_blackwood.json
+++ b/src/generated/resources/data/railways/recipe/sequenced_assembly/track_tfc_blackwood.json
@@ -23,10 +23,10 @@
         },
         [
           {
-            "tag": "forge:rods/wrought_iron"
+            "tag": "c:rods/wrought_iron"
           },
           {
-            "tag": "forge:rods/zinc"
+            "tag": "c:rods/zinc"
           }
         ]
       ],
@@ -44,10 +44,10 @@
         },
         [
           {
-            "tag": "forge:rods/wrought_iron"
+            "tag": "c:rods/wrought_iron"
           },
           {
-            "tag": "forge:rods/zinc"
+            "tag": "c:rods/zinc"
           }
         ]
       ],

--- a/src/generated/resources/data/railways/recipe/sequenced_assembly/track_tfc_blackwood_narrow.json
+++ b/src/generated/resources/data/railways/recipe/sequenced_assembly/track_tfc_blackwood_narrow.json
@@ -36,10 +36,10 @@
         },
         [
           {
-            "tag": "forge:rods/wrought_iron"
+            "tag": "c:rods/wrought_iron"
           },
           {
-            "tag": "forge:rods/zinc"
+            "tag": "c:rods/zinc"
           }
         ]
       ],

--- a/src/generated/resources/data/railways/recipe/sequenced_assembly/track_tfc_chestnut.json
+++ b/src/generated/resources/data/railways/recipe/sequenced_assembly/track_tfc_chestnut.json
@@ -23,10 +23,10 @@
         },
         [
           {
-            "tag": "forge:rods/wrought_iron"
+            "tag": "c:rods/wrought_iron"
           },
           {
-            "tag": "forge:rods/zinc"
+            "tag": "c:rods/zinc"
           }
         ]
       ],
@@ -44,10 +44,10 @@
         },
         [
           {
-            "tag": "forge:rods/wrought_iron"
+            "tag": "c:rods/wrought_iron"
           },
           {
-            "tag": "forge:rods/zinc"
+            "tag": "c:rods/zinc"
           }
         ]
       ],

--- a/src/generated/resources/data/railways/recipe/sequenced_assembly/track_tfc_chestnut_narrow.json
+++ b/src/generated/resources/data/railways/recipe/sequenced_assembly/track_tfc_chestnut_narrow.json
@@ -36,10 +36,10 @@
         },
         [
           {
-            "tag": "forge:rods/wrought_iron"
+            "tag": "c:rods/wrought_iron"
           },
           {
-            "tag": "forge:rods/zinc"
+            "tag": "c:rods/zinc"
           }
         ]
       ],

--- a/src/generated/resources/data/railways/recipe/sequenced_assembly/track_tfc_douglas_fir.json
+++ b/src/generated/resources/data/railways/recipe/sequenced_assembly/track_tfc_douglas_fir.json
@@ -23,10 +23,10 @@
         },
         [
           {
-            "tag": "forge:rods/wrought_iron"
+            "tag": "c:rods/wrought_iron"
           },
           {
-            "tag": "forge:rods/zinc"
+            "tag": "c:rods/zinc"
           }
         ]
       ],
@@ -44,10 +44,10 @@
         },
         [
           {
-            "tag": "forge:rods/wrought_iron"
+            "tag": "c:rods/wrought_iron"
           },
           {
-            "tag": "forge:rods/zinc"
+            "tag": "c:rods/zinc"
           }
         ]
       ],

--- a/src/generated/resources/data/railways/recipe/sequenced_assembly/track_tfc_douglas_fir_narrow.json
+++ b/src/generated/resources/data/railways/recipe/sequenced_assembly/track_tfc_douglas_fir_narrow.json
@@ -36,10 +36,10 @@
         },
         [
           {
-            "tag": "forge:rods/wrought_iron"
+            "tag": "c:rods/wrought_iron"
           },
           {
-            "tag": "forge:rods/zinc"
+            "tag": "c:rods/zinc"
           }
         ]
       ],

--- a/src/generated/resources/data/railways/recipe/sequenced_assembly/track_tfc_hickory.json
+++ b/src/generated/resources/data/railways/recipe/sequenced_assembly/track_tfc_hickory.json
@@ -23,10 +23,10 @@
         },
         [
           {
-            "tag": "forge:rods/wrought_iron"
+            "tag": "c:rods/wrought_iron"
           },
           {
-            "tag": "forge:rods/zinc"
+            "tag": "c:rods/zinc"
           }
         ]
       ],
@@ -44,10 +44,10 @@
         },
         [
           {
-            "tag": "forge:rods/wrought_iron"
+            "tag": "c:rods/wrought_iron"
           },
           {
-            "tag": "forge:rods/zinc"
+            "tag": "c:rods/zinc"
           }
         ]
       ],

--- a/src/generated/resources/data/railways/recipe/sequenced_assembly/track_tfc_hickory_narrow.json
+++ b/src/generated/resources/data/railways/recipe/sequenced_assembly/track_tfc_hickory_narrow.json
@@ -36,10 +36,10 @@
         },
         [
           {
-            "tag": "forge:rods/wrought_iron"
+            "tag": "c:rods/wrought_iron"
           },
           {
-            "tag": "forge:rods/zinc"
+            "tag": "c:rods/zinc"
           }
         ]
       ],

--- a/src/generated/resources/data/railways/recipe/sequenced_assembly/track_tfc_kapok.json
+++ b/src/generated/resources/data/railways/recipe/sequenced_assembly/track_tfc_kapok.json
@@ -23,10 +23,10 @@
         },
         [
           {
-            "tag": "forge:rods/wrought_iron"
+            "tag": "c:rods/wrought_iron"
           },
           {
-            "tag": "forge:rods/zinc"
+            "tag": "c:rods/zinc"
           }
         ]
       ],
@@ -44,10 +44,10 @@
         },
         [
           {
-            "tag": "forge:rods/wrought_iron"
+            "tag": "c:rods/wrought_iron"
           },
           {
-            "tag": "forge:rods/zinc"
+            "tag": "c:rods/zinc"
           }
         ]
       ],

--- a/src/generated/resources/data/railways/recipe/sequenced_assembly/track_tfc_kapok_narrow.json
+++ b/src/generated/resources/data/railways/recipe/sequenced_assembly/track_tfc_kapok_narrow.json
@@ -36,10 +36,10 @@
         },
         [
           {
-            "tag": "forge:rods/wrought_iron"
+            "tag": "c:rods/wrought_iron"
           },
           {
-            "tag": "forge:rods/zinc"
+            "tag": "c:rods/zinc"
           }
         ]
       ],

--- a/src/generated/resources/data/railways/recipe/sequenced_assembly/track_tfc_mangrove.json
+++ b/src/generated/resources/data/railways/recipe/sequenced_assembly/track_tfc_mangrove.json
@@ -23,10 +23,10 @@
         },
         [
           {
-            "tag": "forge:rods/wrought_iron"
+            "tag": "c:rods/wrought_iron"
           },
           {
-            "tag": "forge:rods/zinc"
+            "tag": "c:rods/zinc"
           }
         ]
       ],
@@ -44,10 +44,10 @@
         },
         [
           {
-            "tag": "forge:rods/wrought_iron"
+            "tag": "c:rods/wrought_iron"
           },
           {
-            "tag": "forge:rods/zinc"
+            "tag": "c:rods/zinc"
           }
         ]
       ],

--- a/src/generated/resources/data/railways/recipe/sequenced_assembly/track_tfc_mangrove_narrow.json
+++ b/src/generated/resources/data/railways/recipe/sequenced_assembly/track_tfc_mangrove_narrow.json
@@ -36,10 +36,10 @@
         },
         [
           {
-            "tag": "forge:rods/wrought_iron"
+            "tag": "c:rods/wrought_iron"
           },
           {
-            "tag": "forge:rods/zinc"
+            "tag": "c:rods/zinc"
           }
         ]
       ],

--- a/src/generated/resources/data/railways/recipe/sequenced_assembly/track_tfc_maple.json
+++ b/src/generated/resources/data/railways/recipe/sequenced_assembly/track_tfc_maple.json
@@ -23,10 +23,10 @@
         },
         [
           {
-            "tag": "forge:rods/wrought_iron"
+            "tag": "c:rods/wrought_iron"
           },
           {
-            "tag": "forge:rods/zinc"
+            "tag": "c:rods/zinc"
           }
         ]
       ],
@@ -44,10 +44,10 @@
         },
         [
           {
-            "tag": "forge:rods/wrought_iron"
+            "tag": "c:rods/wrought_iron"
           },
           {
-            "tag": "forge:rods/zinc"
+            "tag": "c:rods/zinc"
           }
         ]
       ],

--- a/src/generated/resources/data/railways/recipe/sequenced_assembly/track_tfc_maple_narrow.json
+++ b/src/generated/resources/data/railways/recipe/sequenced_assembly/track_tfc_maple_narrow.json
@@ -36,10 +36,10 @@
         },
         [
           {
-            "tag": "forge:rods/wrought_iron"
+            "tag": "c:rods/wrought_iron"
           },
           {
-            "tag": "forge:rods/zinc"
+            "tag": "c:rods/zinc"
           }
         ]
       ],

--- a/src/generated/resources/data/railways/recipe/sequenced_assembly/track_tfc_oak.json
+++ b/src/generated/resources/data/railways/recipe/sequenced_assembly/track_tfc_oak.json
@@ -23,10 +23,10 @@
         },
         [
           {
-            "tag": "forge:rods/wrought_iron"
+            "tag": "c:rods/wrought_iron"
           },
           {
-            "tag": "forge:rods/zinc"
+            "tag": "c:rods/zinc"
           }
         ]
       ],
@@ -44,10 +44,10 @@
         },
         [
           {
-            "tag": "forge:rods/wrought_iron"
+            "tag": "c:rods/wrought_iron"
           },
           {
-            "tag": "forge:rods/zinc"
+            "tag": "c:rods/zinc"
           }
         ]
       ],

--- a/src/generated/resources/data/railways/recipe/sequenced_assembly/track_tfc_oak_narrow.json
+++ b/src/generated/resources/data/railways/recipe/sequenced_assembly/track_tfc_oak_narrow.json
@@ -36,10 +36,10 @@
         },
         [
           {
-            "tag": "forge:rods/wrought_iron"
+            "tag": "c:rods/wrought_iron"
           },
           {
-            "tag": "forge:rods/zinc"
+            "tag": "c:rods/zinc"
           }
         ]
       ],

--- a/src/generated/resources/data/railways/recipe/sequenced_assembly/track_tfc_palm.json
+++ b/src/generated/resources/data/railways/recipe/sequenced_assembly/track_tfc_palm.json
@@ -23,10 +23,10 @@
         },
         [
           {
-            "tag": "forge:rods/wrought_iron"
+            "tag": "c:rods/wrought_iron"
           },
           {
-            "tag": "forge:rods/zinc"
+            "tag": "c:rods/zinc"
           }
         ]
       ],
@@ -44,10 +44,10 @@
         },
         [
           {
-            "tag": "forge:rods/wrought_iron"
+            "tag": "c:rods/wrought_iron"
           },
           {
-            "tag": "forge:rods/zinc"
+            "tag": "c:rods/zinc"
           }
         ]
       ],

--- a/src/generated/resources/data/railways/recipe/sequenced_assembly/track_tfc_palm_narrow.json
+++ b/src/generated/resources/data/railways/recipe/sequenced_assembly/track_tfc_palm_narrow.json
@@ -36,10 +36,10 @@
         },
         [
           {
-            "tag": "forge:rods/wrought_iron"
+            "tag": "c:rods/wrought_iron"
           },
           {
-            "tag": "forge:rods/zinc"
+            "tag": "c:rods/zinc"
           }
         ]
       ],

--- a/src/generated/resources/data/railways/recipe/sequenced_assembly/track_tfc_pine.json
+++ b/src/generated/resources/data/railways/recipe/sequenced_assembly/track_tfc_pine.json
@@ -23,10 +23,10 @@
         },
         [
           {
-            "tag": "forge:rods/wrought_iron"
+            "tag": "c:rods/wrought_iron"
           },
           {
-            "tag": "forge:rods/zinc"
+            "tag": "c:rods/zinc"
           }
         ]
       ],
@@ -44,10 +44,10 @@
         },
         [
           {
-            "tag": "forge:rods/wrought_iron"
+            "tag": "c:rods/wrought_iron"
           },
           {
-            "tag": "forge:rods/zinc"
+            "tag": "c:rods/zinc"
           }
         ]
       ],

--- a/src/generated/resources/data/railways/recipe/sequenced_assembly/track_tfc_pine_narrow.json
+++ b/src/generated/resources/data/railways/recipe/sequenced_assembly/track_tfc_pine_narrow.json
@@ -36,10 +36,10 @@
         },
         [
           {
-            "tag": "forge:rods/wrought_iron"
+            "tag": "c:rods/wrought_iron"
           },
           {
-            "tag": "forge:rods/zinc"
+            "tag": "c:rods/zinc"
           }
         ]
       ],

--- a/src/generated/resources/data/railways/recipe/sequenced_assembly/track_tfc_rosewood.json
+++ b/src/generated/resources/data/railways/recipe/sequenced_assembly/track_tfc_rosewood.json
@@ -23,10 +23,10 @@
         },
         [
           {
-            "tag": "forge:rods/wrought_iron"
+            "tag": "c:rods/wrought_iron"
           },
           {
-            "tag": "forge:rods/zinc"
+            "tag": "c:rods/zinc"
           }
         ]
       ],
@@ -44,10 +44,10 @@
         },
         [
           {
-            "tag": "forge:rods/wrought_iron"
+            "tag": "c:rods/wrought_iron"
           },
           {
-            "tag": "forge:rods/zinc"
+            "tag": "c:rods/zinc"
           }
         ]
       ],

--- a/src/generated/resources/data/railways/recipe/sequenced_assembly/track_tfc_rosewood_narrow.json
+++ b/src/generated/resources/data/railways/recipe/sequenced_assembly/track_tfc_rosewood_narrow.json
@@ -36,10 +36,10 @@
         },
         [
           {
-            "tag": "forge:rods/wrought_iron"
+            "tag": "c:rods/wrought_iron"
           },
           {
-            "tag": "forge:rods/zinc"
+            "tag": "c:rods/zinc"
           }
         ]
       ],

--- a/src/generated/resources/data/railways/recipe/sequenced_assembly/track_tfc_sequoia.json
+++ b/src/generated/resources/data/railways/recipe/sequenced_assembly/track_tfc_sequoia.json
@@ -23,10 +23,10 @@
         },
         [
           {
-            "tag": "forge:rods/wrought_iron"
+            "tag": "c:rods/wrought_iron"
           },
           {
-            "tag": "forge:rods/zinc"
+            "tag": "c:rods/zinc"
           }
         ]
       ],
@@ -44,10 +44,10 @@
         },
         [
           {
-            "tag": "forge:rods/wrought_iron"
+            "tag": "c:rods/wrought_iron"
           },
           {
-            "tag": "forge:rods/zinc"
+            "tag": "c:rods/zinc"
           }
         ]
       ],

--- a/src/generated/resources/data/railways/recipe/sequenced_assembly/track_tfc_sequoia_narrow.json
+++ b/src/generated/resources/data/railways/recipe/sequenced_assembly/track_tfc_sequoia_narrow.json
@@ -36,10 +36,10 @@
         },
         [
           {
-            "tag": "forge:rods/wrought_iron"
+            "tag": "c:rods/wrought_iron"
           },
           {
-            "tag": "forge:rods/zinc"
+            "tag": "c:rods/zinc"
           }
         ]
       ],

--- a/src/generated/resources/data/railways/recipe/sequenced_assembly/track_tfc_spruce.json
+++ b/src/generated/resources/data/railways/recipe/sequenced_assembly/track_tfc_spruce.json
@@ -23,10 +23,10 @@
         },
         [
           {
-            "tag": "forge:rods/wrought_iron"
+            "tag": "c:rods/wrought_iron"
           },
           {
-            "tag": "forge:rods/zinc"
+            "tag": "c:rods/zinc"
           }
         ]
       ],
@@ -44,10 +44,10 @@
         },
         [
           {
-            "tag": "forge:rods/wrought_iron"
+            "tag": "c:rods/wrought_iron"
           },
           {
-            "tag": "forge:rods/zinc"
+            "tag": "c:rods/zinc"
           }
         ]
       ],

--- a/src/generated/resources/data/railways/recipe/sequenced_assembly/track_tfc_spruce_narrow.json
+++ b/src/generated/resources/data/railways/recipe/sequenced_assembly/track_tfc_spruce_narrow.json
@@ -36,10 +36,10 @@
         },
         [
           {
-            "tag": "forge:rods/wrought_iron"
+            "tag": "c:rods/wrought_iron"
           },
           {
-            "tag": "forge:rods/zinc"
+            "tag": "c:rods/zinc"
           }
         ]
       ],

--- a/src/generated/resources/data/railways/recipe/sequenced_assembly/track_tfc_sycamore.json
+++ b/src/generated/resources/data/railways/recipe/sequenced_assembly/track_tfc_sycamore.json
@@ -23,10 +23,10 @@
         },
         [
           {
-            "tag": "forge:rods/wrought_iron"
+            "tag": "c:rods/wrought_iron"
           },
           {
-            "tag": "forge:rods/zinc"
+            "tag": "c:rods/zinc"
           }
         ]
       ],
@@ -44,10 +44,10 @@
         },
         [
           {
-            "tag": "forge:rods/wrought_iron"
+            "tag": "c:rods/wrought_iron"
           },
           {
-            "tag": "forge:rods/zinc"
+            "tag": "c:rods/zinc"
           }
         ]
       ],

--- a/src/generated/resources/data/railways/recipe/sequenced_assembly/track_tfc_sycamore_narrow.json
+++ b/src/generated/resources/data/railways/recipe/sequenced_assembly/track_tfc_sycamore_narrow.json
@@ -36,10 +36,10 @@
         },
         [
           {
-            "tag": "forge:rods/wrought_iron"
+            "tag": "c:rods/wrought_iron"
           },
           {
-            "tag": "forge:rods/zinc"
+            "tag": "c:rods/zinc"
           }
         ]
       ],

--- a/src/generated/resources/data/railways/recipe/sequenced_assembly/track_tfc_white_cedar.json
+++ b/src/generated/resources/data/railways/recipe/sequenced_assembly/track_tfc_white_cedar.json
@@ -23,10 +23,10 @@
         },
         [
           {
-            "tag": "forge:rods/wrought_iron"
+            "tag": "c:rods/wrought_iron"
           },
           {
-            "tag": "forge:rods/zinc"
+            "tag": "c:rods/zinc"
           }
         ]
       ],
@@ -44,10 +44,10 @@
         },
         [
           {
-            "tag": "forge:rods/wrought_iron"
+            "tag": "c:rods/wrought_iron"
           },
           {
-            "tag": "forge:rods/zinc"
+            "tag": "c:rods/zinc"
           }
         ]
       ],

--- a/src/generated/resources/data/railways/recipe/sequenced_assembly/track_tfc_white_cedar_narrow.json
+++ b/src/generated/resources/data/railways/recipe/sequenced_assembly/track_tfc_white_cedar_narrow.json
@@ -36,10 +36,10 @@
         },
         [
           {
-            "tag": "forge:rods/wrought_iron"
+            "tag": "c:rods/wrought_iron"
           },
           {
-            "tag": "forge:rods/zinc"
+            "tag": "c:rods/zinc"
           }
         ]
       ],

--- a/src/generated/resources/data/railways/recipe/sequenced_assembly/track_tfc_willow.json
+++ b/src/generated/resources/data/railways/recipe/sequenced_assembly/track_tfc_willow.json
@@ -23,10 +23,10 @@
         },
         [
           {
-            "tag": "forge:rods/wrought_iron"
+            "tag": "c:rods/wrought_iron"
           },
           {
-            "tag": "forge:rods/zinc"
+            "tag": "c:rods/zinc"
           }
         ]
       ],
@@ -44,10 +44,10 @@
         },
         [
           {
-            "tag": "forge:rods/wrought_iron"
+            "tag": "c:rods/wrought_iron"
           },
           {
-            "tag": "forge:rods/zinc"
+            "tag": "c:rods/zinc"
           }
         ]
       ],

--- a/src/generated/resources/data/railways/recipe/sequenced_assembly/track_tfc_willow_narrow.json
+++ b/src/generated/resources/data/railways/recipe/sequenced_assembly/track_tfc_willow_narrow.json
@@ -36,10 +36,10 @@
         },
         [
           {
-            "tag": "forge:rods/wrought_iron"
+            "tag": "c:rods/wrought_iron"
           },
           {
-            "tag": "forge:rods/zinc"
+            "tag": "c:rods/zinc"
           }
         ]
       ],

--- a/src/main/java/com/railwayteam/railways/compat/tracks/mods/TFCTrackCompat.java
+++ b/src/main/java/com/railwayteam/railways/compat/tracks/mods/TFCTrackCompat.java
@@ -37,8 +37,8 @@ public class TFCTrackCompat extends GenericTrackCompat {
     @Override
     protected Ingredient getIngredientForRail() {
         return Ingredient.fromValues(Stream.of(
-                AccessorIngredient$TagValue.railways$create(TagKey.create(Registries.ITEM, ResourceLocation.fromNamespaceAndPath("forge", "rods/wrought_iron"))),
-                AccessorIngredient$TagValue.railways$create(TagKey.create(Registries.ITEM, ResourceLocation.fromNamespaceAndPath("forge", "rods/zinc")))
+                AccessorIngredient$TagValue.railways$create(TagKey.create(Registries.ITEM, ResourceLocation.fromNamespaceAndPath("c", "rods/wrought_iron"))),
+                AccessorIngredient$TagValue.railways$create(TagKey.create(Registries.ITEM, ResourceLocation.fromNamespaceAndPath("c", "rods/zinc")))
         ));
     }
 


### PR DESCRIPTION
Closes #291

## Problem

`TFCTrackCompat.getIngredientForRail()` emits `forge:rods/wrought_iron` and `forge:rods/zinc` for the sequenced-assembly deploying step. NeoForge 1.21 dropped the `forge:` tag namespace in favour of the cross-loader `c:` convention, so those tags are populated by nothing. The deploying step gets an empty ingredient, so TFC tracks can't be crafted.

The base `GenericTrackCompat` already uses `c:` tags (via `CommonTags`); only this override kept hardcoded Forge-era `forge:` strings, missed in the NeoForge migration.

## Fix

Point at `c:rods/wrought_iron` and `c:rods/zinc`, both populated by TFC (confirmed in TFC's `c:rods` tag tree), and regenerate the affected `sequenced_assembly` recipes.

- `TFCTrackCompat.java`: `forge` -> `c` on both rod tags
- 40 regenerated `track_tfc_*` recipes (standard + narrow)

## Notes

The recipe JSON changes are a pure namespace swap, identical to what datagen produces from the source change. Verified all TFC recipe files stay valid JSON with only `c:rods/*` tags remaining, and the module compiles.