### PR TITLE
Fixed crash & softlock related to the Jukebox Minecart

### DIFF
--- a/src/main/java/com/railwayteam/railways/content/minecarts/MinecartJukebox.java
+++ b/src/main/java/com/railwayteam/railways/content/minecarts/MinecartJukebox.java
@@ -126,7 +126,11 @@ public class MinecartJukebox extends MinecartBlock {
     if (active && !level().isClientSide) {
       if (cooldownCount <= 0) {
         cooldownCount = COOLDOWN;
-        PacketSender.updateJukeboxClientside(this, this.disc);
+
+          // Guard against saving/sending empty ItemStacks to the client
+          if (!disc.isEmpty()) {
+              PacketSender.updateJukeboxClientside(this, this.disc);
+          }
       }
     }
   }


### PR DESCRIPTION
### Problem
When an empty `MinecartJukebox` passes over a powered activator rail, the game immediately throws an `IllegalStateException` and crashes the entire world tick loop, resulting in a permanent world softlock.

### Cause
In Minecraft 1.21+, the data component system strictly validates network serialization. When the activator rail triggers `activateMinecart` on an empty cart, it attempts to sync the current record state to nearby clients by instantiating a `JukeboxCartPacket` with `this.disc` (which evaluates to `ItemStack.EMPTY`). 

Vanilla's `ItemStack.save()` method now explicitly throws an error if an empty item stack is passed for serialization, bricking the server tick loop.

### Solution
Isolated the network packet line with a `!disc.isEmpty()` guard condition inside `activateMinecart()`. This ensures that if the jukebox cart is empty, it safely absorbs the activator rail signal and goes on cooldown without attempting to send an illegal empty packet across the network.

### Stack Trace
```
java.lang.IllegalStateException: Cannot encode empty ItemStack
	at net.minecraft.world.item.ItemStack.save(ItemStack.java:409)
	at com.railwayteam.railways.util.packet.JukeboxCartPacket.<init>(JukeboxCartPacket.java:21)
	at com.railwayteam.railways.util.packet.PacketSender.updateJukeboxClientside(PacketSender.java:33)
	at com.railwayteam.railways.content.minecarts.MinecartJukebox.activateMinecart(MinecartJukebox.java:129)
	at net.minecraft.world.entity.vehicle.AbstractMinecart.tick(AbstractMinecart.java:287)
```