### PR TITLE
Fix mod_loaded gating for underscore mod ids in compat track loot tables

### DIFF
--- a/src/generated/resources/data/railways/loot_table/blocks/track_blue_skies_bluebright.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_blue_skies_bluebright.json
@@ -17,5 +17,11 @@
       "rolls": 1.0
     }
   ],
-  "random_sequence": "railways:blocks/track_blue_skies_bluebright"
+  "random_sequence": "railways:blocks/track_blue_skies_bluebright",
+  "conditions": [
+    {
+      "condition": "neoforge:mod_loaded",
+      "modid": "blue_skies"
+    }
+  ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_blue_skies_bluebright_narrow.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_blue_skies_bluebright_narrow.json
@@ -17,5 +17,11 @@
       "rolls": 1.0
     }
   ],
-  "random_sequence": "railways:blocks/track_blue_skies_bluebright_narrow"
+  "random_sequence": "railways:blocks/track_blue_skies_bluebright_narrow",
+  "conditions": [
+    {
+      "condition": "neoforge:mod_loaded",
+      "modid": "blue_skies"
+    }
+  ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_blue_skies_bluebright_wide.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_blue_skies_bluebright_wide.json
@@ -17,5 +17,11 @@
       "rolls": 1.0
     }
   ],
-  "random_sequence": "railways:blocks/track_blue_skies_bluebright_wide"
+  "random_sequence": "railways:blocks/track_blue_skies_bluebright_wide",
+  "conditions": [
+    {
+      "condition": "neoforge:mod_loaded",
+      "modid": "blue_skies"
+    }
+  ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_blue_skies_dusk.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_blue_skies_dusk.json
@@ -17,5 +17,11 @@
       "rolls": 1.0
     }
   ],
-  "random_sequence": "railways:blocks/track_blue_skies_dusk"
+  "random_sequence": "railways:blocks/track_blue_skies_dusk",
+  "conditions": [
+    {
+      "condition": "neoforge:mod_loaded",
+      "modid": "blue_skies"
+    }
+  ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_blue_skies_dusk_narrow.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_blue_skies_dusk_narrow.json
@@ -17,5 +17,11 @@
       "rolls": 1.0
     }
   ],
-  "random_sequence": "railways:blocks/track_blue_skies_dusk_narrow"
+  "random_sequence": "railways:blocks/track_blue_skies_dusk_narrow",
+  "conditions": [
+    {
+      "condition": "neoforge:mod_loaded",
+      "modid": "blue_skies"
+    }
+  ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_blue_skies_dusk_wide.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_blue_skies_dusk_wide.json
@@ -17,5 +17,11 @@
       "rolls": 1.0
     }
   ],
-  "random_sequence": "railways:blocks/track_blue_skies_dusk_wide"
+  "random_sequence": "railways:blocks/track_blue_skies_dusk_wide",
+  "conditions": [
+    {
+      "condition": "neoforge:mod_loaded",
+      "modid": "blue_skies"
+    }
+  ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_blue_skies_frostbright.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_blue_skies_frostbright.json
@@ -17,5 +17,11 @@
       "rolls": 1.0
     }
   ],
-  "random_sequence": "railways:blocks/track_blue_skies_frostbright"
+  "random_sequence": "railways:blocks/track_blue_skies_frostbright",
+  "conditions": [
+    {
+      "condition": "neoforge:mod_loaded",
+      "modid": "blue_skies"
+    }
+  ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_blue_skies_frostbright_narrow.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_blue_skies_frostbright_narrow.json
@@ -17,5 +17,11 @@
       "rolls": 1.0
     }
   ],
-  "random_sequence": "railways:blocks/track_blue_skies_frostbright_narrow"
+  "random_sequence": "railways:blocks/track_blue_skies_frostbright_narrow",
+  "conditions": [
+    {
+      "condition": "neoforge:mod_loaded",
+      "modid": "blue_skies"
+    }
+  ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_blue_skies_frostbright_wide.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_blue_skies_frostbright_wide.json
@@ -17,5 +17,11 @@
       "rolls": 1.0
     }
   ],
-  "random_sequence": "railways:blocks/track_blue_skies_frostbright_wide"
+  "random_sequence": "railways:blocks/track_blue_skies_frostbright_wide",
+  "conditions": [
+    {
+      "condition": "neoforge:mod_loaded",
+      "modid": "blue_skies"
+    }
+  ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_blue_skies_lunar.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_blue_skies_lunar.json
@@ -17,5 +17,11 @@
       "rolls": 1.0
     }
   ],
-  "random_sequence": "railways:blocks/track_blue_skies_lunar"
+  "random_sequence": "railways:blocks/track_blue_skies_lunar",
+  "conditions": [
+    {
+      "condition": "neoforge:mod_loaded",
+      "modid": "blue_skies"
+    }
+  ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_blue_skies_lunar_narrow.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_blue_skies_lunar_narrow.json
@@ -17,5 +17,11 @@
       "rolls": 1.0
     }
   ],
-  "random_sequence": "railways:blocks/track_blue_skies_lunar_narrow"
+  "random_sequence": "railways:blocks/track_blue_skies_lunar_narrow",
+  "conditions": [
+    {
+      "condition": "neoforge:mod_loaded",
+      "modid": "blue_skies"
+    }
+  ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_blue_skies_lunar_wide.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_blue_skies_lunar_wide.json
@@ -17,5 +17,11 @@
       "rolls": 1.0
     }
   ],
-  "random_sequence": "railways:blocks/track_blue_skies_lunar_wide"
+  "random_sequence": "railways:blocks/track_blue_skies_lunar_wide",
+  "conditions": [
+    {
+      "condition": "neoforge:mod_loaded",
+      "modid": "blue_skies"
+    }
+  ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_blue_skies_maple.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_blue_skies_maple.json
@@ -17,5 +17,11 @@
       "rolls": 1.0
     }
   ],
-  "random_sequence": "railways:blocks/track_blue_skies_maple"
+  "random_sequence": "railways:blocks/track_blue_skies_maple",
+  "conditions": [
+    {
+      "condition": "neoforge:mod_loaded",
+      "modid": "blue_skies"
+    }
+  ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_blue_skies_maple_narrow.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_blue_skies_maple_narrow.json
@@ -17,5 +17,11 @@
       "rolls": 1.0
     }
   ],
-  "random_sequence": "railways:blocks/track_blue_skies_maple_narrow"
+  "random_sequence": "railways:blocks/track_blue_skies_maple_narrow",
+  "conditions": [
+    {
+      "condition": "neoforge:mod_loaded",
+      "modid": "blue_skies"
+    }
+  ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_blue_skies_maple_wide.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_blue_skies_maple_wide.json
@@ -17,5 +17,11 @@
       "rolls": 1.0
     }
   ],
-  "random_sequence": "railways:blocks/track_blue_skies_maple_wide"
+  "random_sequence": "railways:blocks/track_blue_skies_maple_wide",
+  "conditions": [
+    {
+      "condition": "neoforge:mod_loaded",
+      "modid": "blue_skies"
+    }
+  ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_blue_skies_starlit.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_blue_skies_starlit.json
@@ -17,5 +17,11 @@
       "rolls": 1.0
     }
   ],
-  "random_sequence": "railways:blocks/track_blue_skies_starlit"
+  "random_sequence": "railways:blocks/track_blue_skies_starlit",
+  "conditions": [
+    {
+      "condition": "neoforge:mod_loaded",
+      "modid": "blue_skies"
+    }
+  ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_blue_skies_starlit_narrow.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_blue_skies_starlit_narrow.json
@@ -17,5 +17,11 @@
       "rolls": 1.0
     }
   ],
-  "random_sequence": "railways:blocks/track_blue_skies_starlit_narrow"
+  "random_sequence": "railways:blocks/track_blue_skies_starlit_narrow",
+  "conditions": [
+    {
+      "condition": "neoforge:mod_loaded",
+      "modid": "blue_skies"
+    }
+  ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_blue_skies_starlit_wide.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_blue_skies_starlit_wide.json
@@ -17,5 +17,11 @@
       "rolls": 1.0
     }
   ],
-  "random_sequence": "railways:blocks/track_blue_skies_starlit_wide"
+  "random_sequence": "railways:blocks/track_blue_skies_starlit_wide",
+  "conditions": [
+    {
+      "condition": "neoforge:mod_loaded",
+      "modid": "blue_skies"
+    }
+  ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_create_dd_rose.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_create_dd_rose.json
@@ -17,5 +17,11 @@
       "rolls": 1.0
     }
   ],
-  "random_sequence": "railways:blocks/track_create_dd_rose"
+  "random_sequence": "railways:blocks/track_create_dd_rose",
+  "conditions": [
+    {
+      "condition": "neoforge:mod_loaded",
+      "modid": "create_dd"
+    }
+  ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_create_dd_rose_narrow.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_create_dd_rose_narrow.json
@@ -17,5 +17,11 @@
       "rolls": 1.0
     }
   ],
-  "random_sequence": "railways:blocks/track_create_dd_rose_narrow"
+  "random_sequence": "railways:blocks/track_create_dd_rose_narrow",
+  "conditions": [
+    {
+      "condition": "neoforge:mod_loaded",
+      "modid": "create_dd"
+    }
+  ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_create_dd_rose_wide.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_create_dd_rose_wide.json
@@ -17,5 +17,11 @@
       "rolls": 1.0
     }
   ],
-  "random_sequence": "railways:blocks/track_create_dd_rose_wide"
+  "random_sequence": "railways:blocks/track_create_dd_rose_wide",
+  "conditions": [
+    {
+      "condition": "neoforge:mod_loaded",
+      "modid": "create_dd"
+    }
+  ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_create_dd_rubber.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_create_dd_rubber.json
@@ -17,5 +17,11 @@
       "rolls": 1.0
     }
   ],
-  "random_sequence": "railways:blocks/track_create_dd_rubber"
+  "random_sequence": "railways:blocks/track_create_dd_rubber",
+  "conditions": [
+    {
+      "condition": "neoforge:mod_loaded",
+      "modid": "create_dd"
+    }
+  ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_create_dd_rubber_narrow.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_create_dd_rubber_narrow.json
@@ -17,5 +17,11 @@
       "rolls": 1.0
     }
   ],
-  "random_sequence": "railways:blocks/track_create_dd_rubber_narrow"
+  "random_sequence": "railways:blocks/track_create_dd_rubber_narrow",
+  "conditions": [
+    {
+      "condition": "neoforge:mod_loaded",
+      "modid": "create_dd"
+    }
+  ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_create_dd_rubber_wide.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_create_dd_rubber_wide.json
@@ -17,5 +17,11 @@
       "rolls": 1.0
     }
   ],
-  "random_sequence": "railways:blocks/track_create_dd_rubber_wide"
+  "random_sequence": "railways:blocks/track_create_dd_rubber_wide",
+  "conditions": [
+    {
+      "condition": "neoforge:mod_loaded",
+      "modid": "create_dd"
+    }
+  ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_create_dd_smoked.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_create_dd_smoked.json
@@ -17,5 +17,11 @@
       "rolls": 1.0
     }
   ],
-  "random_sequence": "railways:blocks/track_create_dd_smoked"
+  "random_sequence": "railways:blocks/track_create_dd_smoked",
+  "conditions": [
+    {
+      "condition": "neoforge:mod_loaded",
+      "modid": "create_dd"
+    }
+  ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_create_dd_smoked_narrow.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_create_dd_smoked_narrow.json
@@ -17,5 +17,11 @@
       "rolls": 1.0
     }
   ],
-  "random_sequence": "railways:blocks/track_create_dd_smoked_narrow"
+  "random_sequence": "railways:blocks/track_create_dd_smoked_narrow",
+  "conditions": [
+    {
+      "condition": "neoforge:mod_loaded",
+      "modid": "create_dd"
+    }
+  ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_create_dd_smoked_wide.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_create_dd_smoked_wide.json
@@ -17,5 +17,11 @@
       "rolls": 1.0
     }
   ],
-  "random_sequence": "railways:blocks/track_create_dd_smoked_wide"
+  "random_sequence": "railways:blocks/track_create_dd_smoked_wide",
+  "conditions": [
+    {
+      "condition": "neoforge:mod_loaded",
+      "modid": "create_dd"
+    }
+  ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_create_dd_spirit.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_create_dd_spirit.json
@@ -17,5 +17,11 @@
       "rolls": 1.0
     }
   ],
-  "random_sequence": "railways:blocks/track_create_dd_spirit"
+  "random_sequence": "railways:blocks/track_create_dd_spirit",
+  "conditions": [
+    {
+      "condition": "neoforge:mod_loaded",
+      "modid": "create_dd"
+    }
+  ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_create_dd_spirit_narrow.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_create_dd_spirit_narrow.json
@@ -17,5 +17,11 @@
       "rolls": 1.0
     }
   ],
-  "random_sequence": "railways:blocks/track_create_dd_spirit_narrow"
+  "random_sequence": "railways:blocks/track_create_dd_spirit_narrow",
+  "conditions": [
+    {
+      "condition": "neoforge:mod_loaded",
+      "modid": "create_dd"
+    }
+  ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_create_dd_spirit_wide.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_create_dd_spirit_wide.json
@@ -17,5 +17,11 @@
       "rolls": 1.0
     }
   ],
-  "random_sequence": "railways:blocks/track_create_dd_spirit_wide"
+  "random_sequence": "railways:blocks/track_create_dd_spirit_wide",
+  "conditions": [
+    {
+      "condition": "neoforge:mod_loaded",
+      "modid": "create_dd"
+    }
+  ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_natures_spirit_aspen.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_natures_spirit_aspen.json
@@ -17,5 +17,11 @@
       "rolls": 1.0
     }
   ],
-  "random_sequence": "railways:blocks/track_natures_spirit_aspen"
+  "random_sequence": "railways:blocks/track_natures_spirit_aspen",
+  "conditions": [
+    {
+      "condition": "neoforge:mod_loaded",
+      "modid": "natures_spirit"
+    }
+  ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_natures_spirit_aspen_narrow.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_natures_spirit_aspen_narrow.json
@@ -17,5 +17,11 @@
       "rolls": 1.0
     }
   ],
-  "random_sequence": "railways:blocks/track_natures_spirit_aspen_narrow"
+  "random_sequence": "railways:blocks/track_natures_spirit_aspen_narrow",
+  "conditions": [
+    {
+      "condition": "neoforge:mod_loaded",
+      "modid": "natures_spirit"
+    }
+  ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_natures_spirit_aspen_wide.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_natures_spirit_aspen_wide.json
@@ -17,5 +17,11 @@
       "rolls": 1.0
     }
   ],
-  "random_sequence": "railways:blocks/track_natures_spirit_aspen_wide"
+  "random_sequence": "railways:blocks/track_natures_spirit_aspen_wide",
+  "conditions": [
+    {
+      "condition": "neoforge:mod_loaded",
+      "modid": "natures_spirit"
+    }
+  ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_natures_spirit_cypress.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_natures_spirit_cypress.json
@@ -17,5 +17,11 @@
       "rolls": 1.0
     }
   ],
-  "random_sequence": "railways:blocks/track_natures_spirit_cypress"
+  "random_sequence": "railways:blocks/track_natures_spirit_cypress",
+  "conditions": [
+    {
+      "condition": "neoforge:mod_loaded",
+      "modid": "natures_spirit"
+    }
+  ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_natures_spirit_cypress_narrow.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_natures_spirit_cypress_narrow.json
@@ -17,5 +17,11 @@
       "rolls": 1.0
     }
   ],
-  "random_sequence": "railways:blocks/track_natures_spirit_cypress_narrow"
+  "random_sequence": "railways:blocks/track_natures_spirit_cypress_narrow",
+  "conditions": [
+    {
+      "condition": "neoforge:mod_loaded",
+      "modid": "natures_spirit"
+    }
+  ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_natures_spirit_cypress_wide.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_natures_spirit_cypress_wide.json
@@ -17,5 +17,11 @@
       "rolls": 1.0
     }
   ],
-  "random_sequence": "railways:blocks/track_natures_spirit_cypress_wide"
+  "random_sequence": "railways:blocks/track_natures_spirit_cypress_wide",
+  "conditions": [
+    {
+      "condition": "neoforge:mod_loaded",
+      "modid": "natures_spirit"
+    }
+  ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_natures_spirit_fir.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_natures_spirit_fir.json
@@ -17,5 +17,11 @@
       "rolls": 1.0
     }
   ],
-  "random_sequence": "railways:blocks/track_natures_spirit_fir"
+  "random_sequence": "railways:blocks/track_natures_spirit_fir",
+  "conditions": [
+    {
+      "condition": "neoforge:mod_loaded",
+      "modid": "natures_spirit"
+    }
+  ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_natures_spirit_fir_narrow.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_natures_spirit_fir_narrow.json
@@ -17,5 +17,11 @@
       "rolls": 1.0
     }
   ],
-  "random_sequence": "railways:blocks/track_natures_spirit_fir_narrow"
+  "random_sequence": "railways:blocks/track_natures_spirit_fir_narrow",
+  "conditions": [
+    {
+      "condition": "neoforge:mod_loaded",
+      "modid": "natures_spirit"
+    }
+  ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_natures_spirit_fir_wide.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_natures_spirit_fir_wide.json
@@ -17,5 +17,11 @@
       "rolls": 1.0
     }
   ],
-  "random_sequence": "railways:blocks/track_natures_spirit_fir_wide"
+  "random_sequence": "railways:blocks/track_natures_spirit_fir_wide",
+  "conditions": [
+    {
+      "condition": "neoforge:mod_loaded",
+      "modid": "natures_spirit"
+    }
+  ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_natures_spirit_ghaf.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_natures_spirit_ghaf.json
@@ -17,5 +17,11 @@
       "rolls": 1.0
     }
   ],
-  "random_sequence": "railways:blocks/track_natures_spirit_ghaf"
+  "random_sequence": "railways:blocks/track_natures_spirit_ghaf",
+  "conditions": [
+    {
+      "condition": "neoforge:mod_loaded",
+      "modid": "natures_spirit"
+    }
+  ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_natures_spirit_ghaf_narrow.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_natures_spirit_ghaf_narrow.json
@@ -17,5 +17,11 @@
       "rolls": 1.0
     }
   ],
-  "random_sequence": "railways:blocks/track_natures_spirit_ghaf_narrow"
+  "random_sequence": "railways:blocks/track_natures_spirit_ghaf_narrow",
+  "conditions": [
+    {
+      "condition": "neoforge:mod_loaded",
+      "modid": "natures_spirit"
+    }
+  ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_natures_spirit_ghaf_wide.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_natures_spirit_ghaf_wide.json
@@ -17,5 +17,11 @@
       "rolls": 1.0
     }
   ],
-  "random_sequence": "railways:blocks/track_natures_spirit_ghaf_wide"
+  "random_sequence": "railways:blocks/track_natures_spirit_ghaf_wide",
+  "conditions": [
+    {
+      "condition": "neoforge:mod_loaded",
+      "modid": "natures_spirit"
+    }
+  ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_natures_spirit_joshua.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_natures_spirit_joshua.json
@@ -17,5 +17,11 @@
       "rolls": 1.0
     }
   ],
-  "random_sequence": "railways:blocks/track_natures_spirit_joshua"
+  "random_sequence": "railways:blocks/track_natures_spirit_joshua",
+  "conditions": [
+    {
+      "condition": "neoforge:mod_loaded",
+      "modid": "natures_spirit"
+    }
+  ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_natures_spirit_joshua_narrow.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_natures_spirit_joshua_narrow.json
@@ -17,5 +17,11 @@
       "rolls": 1.0
     }
   ],
-  "random_sequence": "railways:blocks/track_natures_spirit_joshua_narrow"
+  "random_sequence": "railways:blocks/track_natures_spirit_joshua_narrow",
+  "conditions": [
+    {
+      "condition": "neoforge:mod_loaded",
+      "modid": "natures_spirit"
+    }
+  ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_natures_spirit_joshua_wide.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_natures_spirit_joshua_wide.json
@@ -17,5 +17,11 @@
       "rolls": 1.0
     }
   ],
-  "random_sequence": "railways:blocks/track_natures_spirit_joshua_wide"
+  "random_sequence": "railways:blocks/track_natures_spirit_joshua_wide",
+  "conditions": [
+    {
+      "condition": "neoforge:mod_loaded",
+      "modid": "natures_spirit"
+    }
+  ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_natures_spirit_maple.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_natures_spirit_maple.json
@@ -17,5 +17,11 @@
       "rolls": 1.0
     }
   ],
-  "random_sequence": "railways:blocks/track_natures_spirit_maple"
+  "random_sequence": "railways:blocks/track_natures_spirit_maple",
+  "conditions": [
+    {
+      "condition": "neoforge:mod_loaded",
+      "modid": "natures_spirit"
+    }
+  ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_natures_spirit_maple_narrow.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_natures_spirit_maple_narrow.json
@@ -17,5 +17,11 @@
       "rolls": 1.0
     }
   ],
-  "random_sequence": "railways:blocks/track_natures_spirit_maple_narrow"
+  "random_sequence": "railways:blocks/track_natures_spirit_maple_narrow",
+  "conditions": [
+    {
+      "condition": "neoforge:mod_loaded",
+      "modid": "natures_spirit"
+    }
+  ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_natures_spirit_maple_wide.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_natures_spirit_maple_wide.json
@@ -17,5 +17,11 @@
       "rolls": 1.0
     }
   ],
-  "random_sequence": "railways:blocks/track_natures_spirit_maple_wide"
+  "random_sequence": "railways:blocks/track_natures_spirit_maple_wide",
+  "conditions": [
+    {
+      "condition": "neoforge:mod_loaded",
+      "modid": "natures_spirit"
+    }
+  ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_natures_spirit_olive.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_natures_spirit_olive.json
@@ -17,5 +17,11 @@
       "rolls": 1.0
     }
   ],
-  "random_sequence": "railways:blocks/track_natures_spirit_olive"
+  "random_sequence": "railways:blocks/track_natures_spirit_olive",
+  "conditions": [
+    {
+      "condition": "neoforge:mod_loaded",
+      "modid": "natures_spirit"
+    }
+  ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_natures_spirit_olive_narrow.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_natures_spirit_olive_narrow.json
@@ -17,5 +17,11 @@
       "rolls": 1.0
     }
   ],
-  "random_sequence": "railways:blocks/track_natures_spirit_olive_narrow"
+  "random_sequence": "railways:blocks/track_natures_spirit_olive_narrow",
+  "conditions": [
+    {
+      "condition": "neoforge:mod_loaded",
+      "modid": "natures_spirit"
+    }
+  ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_natures_spirit_olive_wide.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_natures_spirit_olive_wide.json
@@ -17,5 +17,11 @@
       "rolls": 1.0
     }
   ],
-  "random_sequence": "railways:blocks/track_natures_spirit_olive_wide"
+  "random_sequence": "railways:blocks/track_natures_spirit_olive_wide",
+  "conditions": [
+    {
+      "condition": "neoforge:mod_loaded",
+      "modid": "natures_spirit"
+    }
+  ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_natures_spirit_palo_verde.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_natures_spirit_palo_verde.json
@@ -17,5 +17,11 @@
       "rolls": 1.0
     }
   ],
-  "random_sequence": "railways:blocks/track_natures_spirit_palo_verde"
+  "random_sequence": "railways:blocks/track_natures_spirit_palo_verde",
+  "conditions": [
+    {
+      "condition": "neoforge:mod_loaded",
+      "modid": "natures_spirit"
+    }
+  ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_natures_spirit_palo_verde_narrow.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_natures_spirit_palo_verde_narrow.json
@@ -17,5 +17,11 @@
       "rolls": 1.0
     }
   ],
-  "random_sequence": "railways:blocks/track_natures_spirit_palo_verde_narrow"
+  "random_sequence": "railways:blocks/track_natures_spirit_palo_verde_narrow",
+  "conditions": [
+    {
+      "condition": "neoforge:mod_loaded",
+      "modid": "natures_spirit"
+    }
+  ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_natures_spirit_palo_verde_wide.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_natures_spirit_palo_verde_wide.json
@@ -17,5 +17,11 @@
       "rolls": 1.0
     }
   ],
-  "random_sequence": "railways:blocks/track_natures_spirit_palo_verde_wide"
+  "random_sequence": "railways:blocks/track_natures_spirit_palo_verde_wide",
+  "conditions": [
+    {
+      "condition": "neoforge:mod_loaded",
+      "modid": "natures_spirit"
+    }
+  ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_natures_spirit_redwood.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_natures_spirit_redwood.json
@@ -17,5 +17,11 @@
       "rolls": 1.0
     }
   ],
-  "random_sequence": "railways:blocks/track_natures_spirit_redwood"
+  "random_sequence": "railways:blocks/track_natures_spirit_redwood",
+  "conditions": [
+    {
+      "condition": "neoforge:mod_loaded",
+      "modid": "natures_spirit"
+    }
+  ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_natures_spirit_redwood_narrow.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_natures_spirit_redwood_narrow.json
@@ -17,5 +17,11 @@
       "rolls": 1.0
     }
   ],
-  "random_sequence": "railways:blocks/track_natures_spirit_redwood_narrow"
+  "random_sequence": "railways:blocks/track_natures_spirit_redwood_narrow",
+  "conditions": [
+    {
+      "condition": "neoforge:mod_loaded",
+      "modid": "natures_spirit"
+    }
+  ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_natures_spirit_redwood_wide.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_natures_spirit_redwood_wide.json
@@ -17,5 +17,11 @@
       "rolls": 1.0
     }
   ],
-  "random_sequence": "railways:blocks/track_natures_spirit_redwood_wide"
+  "random_sequence": "railways:blocks/track_natures_spirit_redwood_wide",
+  "conditions": [
+    {
+      "condition": "neoforge:mod_loaded",
+      "modid": "natures_spirit"
+    }
+  ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_natures_spirit_sugi.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_natures_spirit_sugi.json
@@ -17,5 +17,11 @@
       "rolls": 1.0
     }
   ],
-  "random_sequence": "railways:blocks/track_natures_spirit_sugi"
+  "random_sequence": "railways:blocks/track_natures_spirit_sugi",
+  "conditions": [
+    {
+      "condition": "neoforge:mod_loaded",
+      "modid": "natures_spirit"
+    }
+  ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_natures_spirit_sugi_narrow.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_natures_spirit_sugi_narrow.json
@@ -17,5 +17,11 @@
       "rolls": 1.0
     }
   ],
-  "random_sequence": "railways:blocks/track_natures_spirit_sugi_narrow"
+  "random_sequence": "railways:blocks/track_natures_spirit_sugi_narrow",
+  "conditions": [
+    {
+      "condition": "neoforge:mod_loaded",
+      "modid": "natures_spirit"
+    }
+  ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_natures_spirit_sugi_wide.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_natures_spirit_sugi_wide.json
@@ -17,5 +17,11 @@
       "rolls": 1.0
     }
   ],
-  "random_sequence": "railways:blocks/track_natures_spirit_sugi_wide"
+  "random_sequence": "railways:blocks/track_natures_spirit_sugi_wide",
+  "conditions": [
+    {
+      "condition": "neoforge:mod_loaded",
+      "modid": "natures_spirit"
+    }
+  ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_natures_spirit_willow.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_natures_spirit_willow.json
@@ -17,5 +17,11 @@
       "rolls": 1.0
     }
   ],
-  "random_sequence": "railways:blocks/track_natures_spirit_willow"
+  "random_sequence": "railways:blocks/track_natures_spirit_willow",
+  "conditions": [
+    {
+      "condition": "neoforge:mod_loaded",
+      "modid": "natures_spirit"
+    }
+  ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_natures_spirit_willow_narrow.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_natures_spirit_willow_narrow.json
@@ -17,5 +17,11 @@
       "rolls": 1.0
     }
   ],
-  "random_sequence": "railways:blocks/track_natures_spirit_willow_narrow"
+  "random_sequence": "railways:blocks/track_natures_spirit_willow_narrow",
+  "conditions": [
+    {
+      "condition": "neoforge:mod_loaded",
+      "modid": "natures_spirit"
+    }
+  ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_natures_spirit_willow_wide.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_natures_spirit_willow_wide.json
@@ -17,5 +17,11 @@
       "rolls": 1.0
     }
   ],
-  "random_sequence": "railways:blocks/track_natures_spirit_willow_wide"
+  "random_sequence": "railways:blocks/track_natures_spirit_willow_wide",
+  "conditions": [
+    {
+      "condition": "neoforge:mod_loaded",
+      "modid": "natures_spirit"
+    }
+  ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_natures_spirit_wisteria.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_natures_spirit_wisteria.json
@@ -17,5 +17,11 @@
       "rolls": 1.0
     }
   ],
-  "random_sequence": "railways:blocks/track_natures_spirit_wisteria"
+  "random_sequence": "railways:blocks/track_natures_spirit_wisteria",
+  "conditions": [
+    {
+      "condition": "neoforge:mod_loaded",
+      "modid": "natures_spirit"
+    }
+  ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_natures_spirit_wisteria_narrow.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_natures_spirit_wisteria_narrow.json
@@ -17,5 +17,11 @@
       "rolls": 1.0
     }
   ],
-  "random_sequence": "railways:blocks/track_natures_spirit_wisteria_narrow"
+  "random_sequence": "railways:blocks/track_natures_spirit_wisteria_narrow",
+  "conditions": [
+    {
+      "condition": "neoforge:mod_loaded",
+      "modid": "natures_spirit"
+    }
+  ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_natures_spirit_wisteria_wide.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_natures_spirit_wisteria_wide.json
@@ -17,5 +17,11 @@
       "rolls": 1.0
     }
   ],
-  "random_sequence": "railways:blocks/track_natures_spirit_wisteria_wide"
+  "random_sequence": "railways:blocks/track_natures_spirit_wisteria_wide",
+  "conditions": [
+    {
+      "condition": "neoforge:mod_loaded",
+      "modid": "natures_spirit"
+    }
+  ]
 }

--- a/src/main/java/com/railwayteam/railways/neoforge/datagen/CompatTrackLootTableProvider.java
+++ b/src/main/java/com/railwayteam/railways/neoforge/datagen/CompatTrackLootTableProvider.java
@@ -86,48 +86,49 @@ public class CompatTrackLootTableProvider implements DataProvider {
         try {
             String fileName = filePath.getFileName().toString();
             String nameWithoutExt = fileName.substring(0, fileName.length() - 5); // Remove .json
-            String[] parts = nameWithoutExt.substring("track_".length()).split("_");
-            
-            if (parts.length > 0) {
-                String modPrefix = parts[0];
-                String modId = MOD_ID_MAP.get(modPrefix);
+            String trackName = nameWithoutExt.substring("track_".length());
+
+            String modId = MOD_ID_MAP.entrySet().stream()
+                .filter(entry -> trackName.equals(entry.getKey()) || trackName.startsWith(entry.getKey() + "_"))
+                .max(java.util.Comparator.comparingInt(entry -> entry.getKey().length()))
+                .map(Map.Entry::getValue)
+                .orElse(null);
+
+            if (modId != null) {
+                // Read the JSON
+                String content = new String(java.nio.file.Files.readAllBytes(filePath));
+                JsonObject json = com.google.gson.JsonParser.parseString(content).getAsJsonObject();
                 
-                if (modId != null) {
-                    // Read the JSON
-                    String content = new String(java.nio.file.Files.readAllBytes(filePath));
-                    JsonObject json = com.google.gson.JsonParser.parseString(content).getAsJsonObject();
-                    
-                    // Check if conditions array already exists
-                    if (!json.has("conditions")) {
-                        json.add("conditions", new com.google.gson.JsonArray());
-                    }
-                    
-                    com.google.gson.JsonArray conditions = json.getAsJsonArray("conditions");
-                    
-                    // Check if mod_loaded condition already exists
-                    boolean hasModLoadedCondition = false;
-                    for (JsonElement elem : conditions) {
-                        if (elem.isJsonObject()) {
-                            JsonObject cond = elem.getAsJsonObject();
-                            if ("neoforge:mod_loaded".equals(cond.get("condition").getAsString()) 
-                                && modId.equals(cond.get("modid").getAsString())) {
-                                hasModLoadedCondition = true;
-                                break;
-                            }
+                // Check if conditions array already exists
+                if (!json.has("conditions")) {
+                    json.add("conditions", new com.google.gson.JsonArray());
+                }
+                
+                com.google.gson.JsonArray conditions = json.getAsJsonArray("conditions");
+                
+                // Check if mod_loaded condition already exists
+                boolean hasModLoadedCondition = false;
+                for (JsonElement elem : conditions) {
+                    if (elem.isJsonObject()) {
+                        JsonObject cond = elem.getAsJsonObject();
+                        if ("neoforge:mod_loaded".equals(cond.get("condition").getAsString()) 
+                            && modId.equals(cond.get("modid").getAsString())) {
+                            hasModLoadedCondition = true;
+                            break;
                         }
                     }
+                }
+                
+                // Add the condition if it doesn't exist
+                if (!hasModLoadedCondition) {
+                    JsonObject modLoadedCondition = new JsonObject();
+                    modLoadedCondition.addProperty("condition", "neoforge:mod_loaded");
+                    modLoadedCondition.addProperty("modid", modId);
+                    conditions.add(modLoadedCondition);
                     
-                    // Add the condition if it doesn't exist
-                    if (!hasModLoadedCondition) {
-                        JsonObject modLoadedCondition = new JsonObject();
-                        modLoadedCondition.addProperty("condition", "neoforge:mod_loaded");
-                        modLoadedCondition.addProperty("modid", modId);
-                        conditions.add(modLoadedCondition);
-                        
-                        // Write the modified JSON back
-                        String modifiedContent = new com.google.gson.GsonBuilder().setPrettyPrinting().create().toJson(json);
-                        java.nio.file.Files.write(filePath, modifiedContent.getBytes());
-                    }
+                    // Write the modified JSON back
+                    String modifiedContent = new com.google.gson.GsonBuilder().setPrettyPrinting().create().toJson(json);
+                    java.nio.file.Files.write(filePath, modifiedContent.getBytes());
                 }
             }
         } catch (Exception e) {


### PR DESCRIPTION
Fixes #302.

The loot-table post-processor derives the mod id from the filename with `split("_")[0]`, so mod ids containing an underscore never match `MOD_ID_MAP`:

- `track_blue_skies_*` -> `blue`
- `track_natures_spirit_*` -> `natures`
- `track_create_dd_*` -> `create`

Those 66 tables (blue_skies 18, natures_spirit 36, create_dd 12) shipped without the `neoforge:mod_loaded` condition, so servers without the dep mod log a parse error per table on start. Single-token mods (biomesoplenty, byg, tfc, ...) were unaffected, as was the recipe side, which uses a different mechanism.

Fix: match full `MOD_ID_MAP` keys with `startsWith(key + "_")`, longest match wins, then regenerate. The diff only touches the 66 affected tables; the lang/cache churn datagen also produced on current dev is left out.