### PR TITLE
Fix roller track replace mode never extracting tracks

### DIFF
--- a/src/main/java/com/railwayteam/railways/content/roller_extensions/TrackReplacePaver.java
+++ b/src/main/java/com/railwayteam/railways/content/roller_extensions/TrackReplacePaver.java
@@ -29,10 +29,7 @@ import com.simibubi.create.content.trains.track.TrackBlockEntity;
 import net.createmod.catnip.data.Couple;
 import net.createmod.catnip.data.Pair;
 import net.minecraft.core.BlockPos;
-import net.minecraft.core.component.DataComponents;
-import net.minecraft.world.item.component.CustomData;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.Items;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.properties.Property;
@@ -60,10 +57,7 @@ public class TrackReplacePaver {
         }
         if ((replacedState = context.world.getBlockState(trackPos)).getBlock() instanceof ITrackBlock
                 && stateToPaveWith.getBlock() instanceof ITrackBlock newTrackBlock) {
-            ItemStack filterStack = new ItemStack(Items.PAPER);
-            CustomData filterData = CustomData.of(context.blockEntityData.getCompound("Filter"));
-            filterStack.set(DataComponents.CUSTOM_DATA, filterData);
-            FilterItemStack filter = FilterItemStack.of(filterStack);
+            FilterItemStack filter = context.getFilterFromBE();
             if (replacedState.getBlock() != stateToPaveWith.getBlock()) {
                 boolean restoreBE = false;
                 Pair<Block, Boolean> casingData = null;


### PR DESCRIPTION
Fixes #309.

The roller's track replace mode silently did nothing: `TrackReplacePaver` rebuilt the filter by wrapping the saved `Filter` NBT in a paper item's custom data and passing that stack to `FilterItemStack.of(ItemStack)`. That yields a plain item filter that matches paper, so tracks in the train's inventory never passed it, every extract came back empty, and both the block swap and the curve re-material were skipped without any error.

The 1.20 original used `FilterItemStack.of(CompoundTag)`, which changed signature in 1.21 (now needs a `HolderLookup.Provider`); the paper wrapping looks like a workaround for that. Create already exposes the right call for this: `MovementContext.getFilterFromBE()` deserializes the `Filter` tag with registry context and caches it, and is what Create's own roller logic uses. Swapped the four lines for that.

Verified against the Create 6.0.7-159 bytecode (`FilterItemStack.test` goes straight to `FilterItem.testDirect` for non-empty filters, so the paper filter can never match a track). Not yet reproduced in-game, happy to if wanted.