### PR TITLE
Fix disguised conductor players keeping the full-size hitbox

### DIFF
--- a/src/main/java/com/railwayteam/railways/mixin/MixinPlayer.java
+++ b/src/main/java/com/railwayteam/railways/mixin/MixinPlayer.java
@@ -37,23 +37,14 @@ public abstract class MixinPlayer extends LivingEntity {
         super(entityType, level);
     }
 
-    @Inject(method = "getEyeHeight", at = @At("RETURN"), cancellable = true, require = 0)
-    private void conductorsAreSmaller(Pose pose, EntityDimensions dimensions, CallbackInfoReturnable<Float> cir) {
-        if (ConductorEntity.isPlayerDisguised((Player) (Object) this)) {
-            if (pose == Pose.SLEEPING || pose == Pose.FALL_FLYING || pose == Pose.SPIN_ATTACK || pose == Pose.SWIMMING || pose == Pose.DYING)
-                return;
-            // conductor eye height is 1.5 * 0.76
-            // player eye height is 1.62
-            cir.setReturnValue(cir.getReturnValueF() * (1.5f * 0.76f / 1.62f));
-        }
-    }
-
-    @Inject(method = "getDimensions", at = @At("RETURN"), cancellable = true)
+    @Inject(method = "getDefaultDimensions", at = @At("RETURN"), cancellable = true)
     private void shrinkConductorPlayer(Pose pose, CallbackInfoReturnable<EntityDimensions> cir) {
         if (ConductorEntity.isPlayerDisguised((Player) (Object) this)) {
             if (pose == Pose.SLEEPING || pose == Pose.FALL_FLYING || pose == Pose.SPIN_ATTACK || pose == Pose.SWIMMING || pose == Pose.DYING) return;
             EntityDimensions dimensions = cir.getReturnValue();
-            cir.setReturnValue(dimensions.scale(1.0f, 1.5f / 1.8f));
+            // conductor eye height is 1.5 * 0.76, player eye height is 1.62
+            cir.setReturnValue(dimensions.scale(1.0f, 1.5f / 1.8f)
+                    .withEyeHeight(dimensions.eyeHeight() * (1.5f * 0.76f / 1.62f)));
         }
     }
 


### PR DESCRIPTION
Fixes #318.

The player-shrinking half of the sus cap easter egg has been dead since the port: `MixinPlayer` injects into `Player#getDimensions` and `Player#getEyeHeight`, but the 1.20.5 entity dimensions refactor removed both (the pose-size hook is now `getDefaultDimensions`, and eye height lives inside `EntityDimensions`). Both injections failed silently, so the model shrank while the collision box stayed 1.8 tall, which is the double-hitbox the reporter screenshotted.

Retargeted the injection to `getDefaultDimensions` and set the scaled eye height explicitly on the returned dimensions. The values match the old behavior: 1.5 tall box, 1.14 eye height (the eye factor differs from the box factor, so `withEyeHeight` rather than plain `scale`).

Verified in-game on a dedicated server: with a sus-named cap the player walks under a 1.5-block gap (top-half slab ceiling) and shows a single shrunken hitbox; without the cap they are blocked as normal.