### PR TITLE
Fix incorrect texture reference for radial bogey

### DIFF
--- a/src/main/resources/assets/railways/models/block/bogey/radial/frame.json
+++ b/src/main/resources/assets/railways/models/block/bogey/radial/frame.json
@@ -5,7 +5,7 @@
   "flip_v": true,
   "model": "railways:models/block/bogey/radial/frame.obj",
   "textures": {
-    "0": "railways:block/bogeys/standard/radial_body",
+    "0": "railways:block/bogeys/standard/radial_frame",
     "1": "create:block/bogey/wheel"
   }
 }


### PR DESCRIPTION
The radial bogey frame.json incorrectly referenced radial_body instead of radial_frame, causing missing textures when the model is loaded via standard JSON model loaders (e.g., when modified by addons like Simurail).