### PR TITLE
Fix client crash when hovering a signal whose track was broken

### DIFF
--- a/src/main/java/com/railwayteam/railways/content/qol/TrackEdgePointHighlighter.java
+++ b/src/main/java/com/railwayteam/railways/content/qol/TrackEdgePointHighlighter.java
@@ -158,7 +158,7 @@ public class TrackEdgePointHighlighter {
                 .colored(Color.SPRING_GREEN)
                 .lineWidth(1 / 16f);
 
-            if (be instanceof SignalBlockEntity) {
+            if (be instanceof SignalBlockEntity && trackTarget1.hasValidTrack()) {
                 TrackGraphLocation location = trackTarget1.determineGraphLocation();
                 if (location != null) {
                     TrackEdge edge = location.graph.getConnection(location.edge.map(location.graph::locateNode));


### PR DESCRIPTION
Fixes #334.

The wrench edge-point highlighter called `determineGraphLocation()` on signals whose bound track had been broken. Create's `TrackTargetingBehaviour.getTrack()` casts the block at the stored track position to `ITrackBlock` unchecked, so with the track gone that's a `ClassCastException` every client tick while hovering the signal.

- guard with `hasValidTrack()` first, same as Create's own callers (thanks @Crendgrim for pointing at it)
- with a broken track the signal now just shows the outline box without the direction arrow, no crash
- checked the other `determineGraphLocation()` call sites in the fork: the only other client-side one (`CustomTrackOverlayRendering.overlayWillOverlap`) already swallows exceptions, the rest are server-side paths that get invalidated on track removal

Verified in-game: track + signal, break track, hover with wrench.
