### PR TITLE
Remove unnecessary cast that can cause a crash

### DIFF
--- a/src/main/java/com/railwayteam/railways/mixin/MixinBezierConnection.java
+++ b/src/main/java/com/railwayteam/railways/mixin/MixinBezierConnection.java
@@ -120,7 +120,7 @@ public abstract class MixinBezierConnection implements IHasTrackCasing {
   @Inject(method = "<init>(Lnet/minecraft/network/FriendlyByteBuf;)V", at = @At("RETURN"), remap = true)
   private void byteBufConstructor(FriendlyByteBuf buffer, CallbackInfo ci) {
     if (buffer.readBoolean()) {
-      setTrackCasing((SlabBlock) BuiltInRegistries.BLOCK.get(buffer.readResourceLocation()));
+      setTrackCasing(BuiltInRegistries.BLOCK.get(buffer.readResourceLocation()));
       setAlternate(buffer.readBoolean());
     } else {
       setTrackCasing(null);


### PR DESCRIPTION
This fix removes an unnecessary cast which can cause the game to crash when tracks are snowed in