### PR TITLE
Fix stale byg mod id in compat slab tags and loot tables

### DIFF
--- a/src/generated/resources/data/railways/loot_table/blocks/track_byg_aspen.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_byg_aspen.json
@@ -21,7 +21,7 @@
   "conditions": [
     {
       "condition": "neoforge:mod_loaded",
-      "modid": "byg"
+      "modid": "biomeswevegone"
     }
   ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_byg_aspen_narrow.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_byg_aspen_narrow.json
@@ -21,7 +21,7 @@
   "conditions": [
     {
       "condition": "neoforge:mod_loaded",
-      "modid": "byg"
+      "modid": "biomeswevegone"
     }
   ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_byg_aspen_wide.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_byg_aspen_wide.json
@@ -21,7 +21,7 @@
   "conditions": [
     {
       "condition": "neoforge:mod_loaded",
-      "modid": "byg"
+      "modid": "biomeswevegone"
     }
   ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_byg_baobab.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_byg_baobab.json
@@ -21,7 +21,7 @@
   "conditions": [
     {
       "condition": "neoforge:mod_loaded",
-      "modid": "byg"
+      "modid": "biomeswevegone"
     }
   ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_byg_baobab_narrow.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_byg_baobab_narrow.json
@@ -21,7 +21,7 @@
   "conditions": [
     {
       "condition": "neoforge:mod_loaded",
-      "modid": "byg"
+      "modid": "biomeswevegone"
     }
   ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_byg_baobab_wide.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_byg_baobab_wide.json
@@ -21,7 +21,7 @@
   "conditions": [
     {
       "condition": "neoforge:mod_loaded",
-      "modid": "byg"
+      "modid": "biomeswevegone"
     }
   ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_byg_blue_enchanted.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_byg_blue_enchanted.json
@@ -21,7 +21,7 @@
   "conditions": [
     {
       "condition": "neoforge:mod_loaded",
-      "modid": "byg"
+      "modid": "biomeswevegone"
     }
   ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_byg_blue_enchanted_narrow.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_byg_blue_enchanted_narrow.json
@@ -21,7 +21,7 @@
   "conditions": [
     {
       "condition": "neoforge:mod_loaded",
-      "modid": "byg"
+      "modid": "biomeswevegone"
     }
   ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_byg_blue_enchanted_wide.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_byg_blue_enchanted_wide.json
@@ -21,7 +21,7 @@
   "conditions": [
     {
       "condition": "neoforge:mod_loaded",
-      "modid": "byg"
+      "modid": "biomeswevegone"
     }
   ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_byg_bulbis.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_byg_bulbis.json
@@ -21,7 +21,7 @@
   "conditions": [
     {
       "condition": "neoforge:mod_loaded",
-      "modid": "byg"
+      "modid": "biomeswevegone"
     }
   ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_byg_bulbis_narrow.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_byg_bulbis_narrow.json
@@ -21,7 +21,7 @@
   "conditions": [
     {
       "condition": "neoforge:mod_loaded",
-      "modid": "byg"
+      "modid": "biomeswevegone"
     }
   ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_byg_bulbis_wide.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_byg_bulbis_wide.json
@@ -21,7 +21,7 @@
   "conditions": [
     {
       "condition": "neoforge:mod_loaded",
-      "modid": "byg"
+      "modid": "biomeswevegone"
     }
   ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_byg_cika.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_byg_cika.json
@@ -21,7 +21,7 @@
   "conditions": [
     {
       "condition": "neoforge:mod_loaded",
-      "modid": "byg"
+      "modid": "biomeswevegone"
     }
   ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_byg_cika_narrow.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_byg_cika_narrow.json
@@ -21,7 +21,7 @@
   "conditions": [
     {
       "condition": "neoforge:mod_loaded",
-      "modid": "byg"
+      "modid": "biomeswevegone"
     }
   ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_byg_cika_wide.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_byg_cika_wide.json
@@ -21,7 +21,7 @@
   "conditions": [
     {
       "condition": "neoforge:mod_loaded",
-      "modid": "byg"
+      "modid": "biomeswevegone"
     }
   ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_byg_cypress.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_byg_cypress.json
@@ -21,7 +21,7 @@
   "conditions": [
     {
       "condition": "neoforge:mod_loaded",
-      "modid": "byg"
+      "modid": "biomeswevegone"
     }
   ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_byg_cypress_narrow.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_byg_cypress_narrow.json
@@ -21,7 +21,7 @@
   "conditions": [
     {
       "condition": "neoforge:mod_loaded",
-      "modid": "byg"
+      "modid": "biomeswevegone"
     }
   ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_byg_cypress_wide.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_byg_cypress_wide.json
@@ -21,7 +21,7 @@
   "conditions": [
     {
       "condition": "neoforge:mod_loaded",
-      "modid": "byg"
+      "modid": "biomeswevegone"
     }
   ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_byg_ebony.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_byg_ebony.json
@@ -21,7 +21,7 @@
   "conditions": [
     {
       "condition": "neoforge:mod_loaded",
-      "modid": "byg"
+      "modid": "biomeswevegone"
     }
   ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_byg_ebony_narrow.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_byg_ebony_narrow.json
@@ -21,7 +21,7 @@
   "conditions": [
     {
       "condition": "neoforge:mod_loaded",
-      "modid": "byg"
+      "modid": "biomeswevegone"
     }
   ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_byg_ebony_wide.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_byg_ebony_wide.json
@@ -21,7 +21,7 @@
   "conditions": [
     {
       "condition": "neoforge:mod_loaded",
-      "modid": "byg"
+      "modid": "biomeswevegone"
     }
   ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_byg_embur.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_byg_embur.json
@@ -21,7 +21,7 @@
   "conditions": [
     {
       "condition": "neoforge:mod_loaded",
-      "modid": "byg"
+      "modid": "biomeswevegone"
     }
   ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_byg_embur_narrow.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_byg_embur_narrow.json
@@ -21,7 +21,7 @@
   "conditions": [
     {
       "condition": "neoforge:mod_loaded",
-      "modid": "byg"
+      "modid": "biomeswevegone"
     }
   ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_byg_embur_wide.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_byg_embur_wide.json
@@ -21,7 +21,7 @@
   "conditions": [
     {
       "condition": "neoforge:mod_loaded",
-      "modid": "byg"
+      "modid": "biomeswevegone"
     }
   ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_byg_ether.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_byg_ether.json
@@ -21,7 +21,7 @@
   "conditions": [
     {
       "condition": "neoforge:mod_loaded",
-      "modid": "byg"
+      "modid": "biomeswevegone"
     }
   ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_byg_ether_narrow.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_byg_ether_narrow.json
@@ -21,7 +21,7 @@
   "conditions": [
     {
       "condition": "neoforge:mod_loaded",
-      "modid": "byg"
+      "modid": "biomeswevegone"
     }
   ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_byg_ether_wide.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_byg_ether_wide.json
@@ -21,7 +21,7 @@
   "conditions": [
     {
       "condition": "neoforge:mod_loaded",
-      "modid": "byg"
+      "modid": "biomeswevegone"
     }
   ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_byg_fir.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_byg_fir.json
@@ -21,7 +21,7 @@
   "conditions": [
     {
       "condition": "neoforge:mod_loaded",
-      "modid": "byg"
+      "modid": "biomeswevegone"
     }
   ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_byg_fir_narrow.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_byg_fir_narrow.json
@@ -21,7 +21,7 @@
   "conditions": [
     {
       "condition": "neoforge:mod_loaded",
-      "modid": "byg"
+      "modid": "biomeswevegone"
     }
   ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_byg_fir_wide.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_byg_fir_wide.json
@@ -21,7 +21,7 @@
   "conditions": [
     {
       "condition": "neoforge:mod_loaded",
-      "modid": "byg"
+      "modid": "biomeswevegone"
     }
   ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_byg_green_enchanted.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_byg_green_enchanted.json
@@ -21,7 +21,7 @@
   "conditions": [
     {
       "condition": "neoforge:mod_loaded",
-      "modid": "byg"
+      "modid": "biomeswevegone"
     }
   ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_byg_green_enchanted_narrow.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_byg_green_enchanted_narrow.json
@@ -21,7 +21,7 @@
   "conditions": [
     {
       "condition": "neoforge:mod_loaded",
-      "modid": "byg"
+      "modid": "biomeswevegone"
     }
   ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_byg_green_enchanted_wide.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_byg_green_enchanted_wide.json
@@ -21,7 +21,7 @@
   "conditions": [
     {
       "condition": "neoforge:mod_loaded",
-      "modid": "byg"
+      "modid": "biomeswevegone"
     }
   ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_byg_holly.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_byg_holly.json
@@ -21,7 +21,7 @@
   "conditions": [
     {
       "condition": "neoforge:mod_loaded",
-      "modid": "byg"
+      "modid": "biomeswevegone"
     }
   ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_byg_holly_narrow.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_byg_holly_narrow.json
@@ -21,7 +21,7 @@
   "conditions": [
     {
       "condition": "neoforge:mod_loaded",
-      "modid": "byg"
+      "modid": "biomeswevegone"
     }
   ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_byg_holly_wide.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_byg_holly_wide.json
@@ -21,7 +21,7 @@
   "conditions": [
     {
       "condition": "neoforge:mod_loaded",
-      "modid": "byg"
+      "modid": "biomeswevegone"
     }
   ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_byg_imparius.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_byg_imparius.json
@@ -21,7 +21,7 @@
   "conditions": [
     {
       "condition": "neoforge:mod_loaded",
-      "modid": "byg"
+      "modid": "biomeswevegone"
     }
   ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_byg_imparius_narrow.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_byg_imparius_narrow.json
@@ -21,7 +21,7 @@
   "conditions": [
     {
       "condition": "neoforge:mod_loaded",
-      "modid": "byg"
+      "modid": "biomeswevegone"
     }
   ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_byg_imparius_wide.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_byg_imparius_wide.json
@@ -21,7 +21,7 @@
   "conditions": [
     {
       "condition": "neoforge:mod_loaded",
-      "modid": "byg"
+      "modid": "biomeswevegone"
     }
   ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_byg_jacaranda.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_byg_jacaranda.json
@@ -21,7 +21,7 @@
   "conditions": [
     {
       "condition": "neoforge:mod_loaded",
-      "modid": "byg"
+      "modid": "biomeswevegone"
     }
   ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_byg_jacaranda_narrow.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_byg_jacaranda_narrow.json
@@ -21,7 +21,7 @@
   "conditions": [
     {
       "condition": "neoforge:mod_loaded",
-      "modid": "byg"
+      "modid": "biomeswevegone"
     }
   ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_byg_jacaranda_wide.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_byg_jacaranda_wide.json
@@ -21,7 +21,7 @@
   "conditions": [
     {
       "condition": "neoforge:mod_loaded",
-      "modid": "byg"
+      "modid": "biomeswevegone"
     }
   ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_byg_lament.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_byg_lament.json
@@ -21,7 +21,7 @@
   "conditions": [
     {
       "condition": "neoforge:mod_loaded",
-      "modid": "byg"
+      "modid": "biomeswevegone"
     }
   ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_byg_lament_narrow.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_byg_lament_narrow.json
@@ -21,7 +21,7 @@
   "conditions": [
     {
       "condition": "neoforge:mod_loaded",
-      "modid": "byg"
+      "modid": "biomeswevegone"
     }
   ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_byg_lament_wide.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_byg_lament_wide.json
@@ -21,7 +21,7 @@
   "conditions": [
     {
       "condition": "neoforge:mod_loaded",
-      "modid": "byg"
+      "modid": "biomeswevegone"
     }
   ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_byg_mahogany.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_byg_mahogany.json
@@ -21,7 +21,7 @@
   "conditions": [
     {
       "condition": "neoforge:mod_loaded",
-      "modid": "byg"
+      "modid": "biomeswevegone"
     }
   ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_byg_mahogany_narrow.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_byg_mahogany_narrow.json
@@ -21,7 +21,7 @@
   "conditions": [
     {
       "condition": "neoforge:mod_loaded",
-      "modid": "byg"
+      "modid": "biomeswevegone"
     }
   ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_byg_mahogany_wide.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_byg_mahogany_wide.json
@@ -21,7 +21,7 @@
   "conditions": [
     {
       "condition": "neoforge:mod_loaded",
-      "modid": "byg"
+      "modid": "biomeswevegone"
     }
   ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_byg_maple.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_byg_maple.json
@@ -21,7 +21,7 @@
   "conditions": [
     {
       "condition": "neoforge:mod_loaded",
-      "modid": "byg"
+      "modid": "biomeswevegone"
     }
   ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_byg_maple_narrow.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_byg_maple_narrow.json
@@ -21,7 +21,7 @@
   "conditions": [
     {
       "condition": "neoforge:mod_loaded",
-      "modid": "byg"
+      "modid": "biomeswevegone"
     }
   ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_byg_maple_wide.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_byg_maple_wide.json
@@ -21,7 +21,7 @@
   "conditions": [
     {
       "condition": "neoforge:mod_loaded",
-      "modid": "byg"
+      "modid": "biomeswevegone"
     }
   ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_byg_nightshade.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_byg_nightshade.json
@@ -21,7 +21,7 @@
   "conditions": [
     {
       "condition": "neoforge:mod_loaded",
-      "modid": "byg"
+      "modid": "biomeswevegone"
     }
   ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_byg_nightshade_narrow.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_byg_nightshade_narrow.json
@@ -21,7 +21,7 @@
   "conditions": [
     {
       "condition": "neoforge:mod_loaded",
-      "modid": "byg"
+      "modid": "biomeswevegone"
     }
   ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_byg_nightshade_wide.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_byg_nightshade_wide.json
@@ -21,7 +21,7 @@
   "conditions": [
     {
       "condition": "neoforge:mod_loaded",
-      "modid": "byg"
+      "modid": "biomeswevegone"
     }
   ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_byg_palm.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_byg_palm.json
@@ -21,7 +21,7 @@
   "conditions": [
     {
       "condition": "neoforge:mod_loaded",
-      "modid": "byg"
+      "modid": "biomeswevegone"
     }
   ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_byg_palm_narrow.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_byg_palm_narrow.json
@@ -21,7 +21,7 @@
   "conditions": [
     {
       "condition": "neoforge:mod_loaded",
-      "modid": "byg"
+      "modid": "biomeswevegone"
     }
   ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_byg_palm_wide.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_byg_palm_wide.json
@@ -21,7 +21,7 @@
   "conditions": [
     {
       "condition": "neoforge:mod_loaded",
-      "modid": "byg"
+      "modid": "biomeswevegone"
     }
   ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_byg_pine.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_byg_pine.json
@@ -21,7 +21,7 @@
   "conditions": [
     {
       "condition": "neoforge:mod_loaded",
-      "modid": "byg"
+      "modid": "biomeswevegone"
     }
   ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_byg_pine_narrow.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_byg_pine_narrow.json
@@ -21,7 +21,7 @@
   "conditions": [
     {
       "condition": "neoforge:mod_loaded",
-      "modid": "byg"
+      "modid": "biomeswevegone"
     }
   ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_byg_pine_wide.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_byg_pine_wide.json
@@ -21,7 +21,7 @@
   "conditions": [
     {
       "condition": "neoforge:mod_loaded",
-      "modid": "byg"
+      "modid": "biomeswevegone"
     }
   ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_byg_rainbow_eucalyptus.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_byg_rainbow_eucalyptus.json
@@ -21,7 +21,7 @@
   "conditions": [
     {
       "condition": "neoforge:mod_loaded",
-      "modid": "byg"
+      "modid": "biomeswevegone"
     }
   ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_byg_rainbow_eucalyptus_narrow.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_byg_rainbow_eucalyptus_narrow.json
@@ -21,7 +21,7 @@
   "conditions": [
     {
       "condition": "neoforge:mod_loaded",
-      "modid": "byg"
+      "modid": "biomeswevegone"
     }
   ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_byg_rainbow_eucalyptus_wide.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_byg_rainbow_eucalyptus_wide.json
@@ -21,7 +21,7 @@
   "conditions": [
     {
       "condition": "neoforge:mod_loaded",
-      "modid": "byg"
+      "modid": "biomeswevegone"
     }
   ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_byg_redwood.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_byg_redwood.json
@@ -21,7 +21,7 @@
   "conditions": [
     {
       "condition": "neoforge:mod_loaded",
-      "modid": "byg"
+      "modid": "biomeswevegone"
     }
   ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_byg_redwood_narrow.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_byg_redwood_narrow.json
@@ -21,7 +21,7 @@
   "conditions": [
     {
       "condition": "neoforge:mod_loaded",
-      "modid": "byg"
+      "modid": "biomeswevegone"
     }
   ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_byg_redwood_wide.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_byg_redwood_wide.json
@@ -21,7 +21,7 @@
   "conditions": [
     {
       "condition": "neoforge:mod_loaded",
-      "modid": "byg"
+      "modid": "biomeswevegone"
     }
   ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_byg_skyris.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_byg_skyris.json
@@ -21,7 +21,7 @@
   "conditions": [
     {
       "condition": "neoforge:mod_loaded",
-      "modid": "byg"
+      "modid": "biomeswevegone"
     }
   ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_byg_skyris_narrow.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_byg_skyris_narrow.json
@@ -21,7 +21,7 @@
   "conditions": [
     {
       "condition": "neoforge:mod_loaded",
-      "modid": "byg"
+      "modid": "biomeswevegone"
     }
   ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_byg_skyris_wide.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_byg_skyris_wide.json
@@ -21,7 +21,7 @@
   "conditions": [
     {
       "condition": "neoforge:mod_loaded",
-      "modid": "byg"
+      "modid": "biomeswevegone"
     }
   ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_byg_sythian.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_byg_sythian.json
@@ -21,7 +21,7 @@
   "conditions": [
     {
       "condition": "neoforge:mod_loaded",
-      "modid": "byg"
+      "modid": "biomeswevegone"
     }
   ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_byg_sythian_narrow.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_byg_sythian_narrow.json
@@ -21,7 +21,7 @@
   "conditions": [
     {
       "condition": "neoforge:mod_loaded",
-      "modid": "byg"
+      "modid": "biomeswevegone"
     }
   ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_byg_sythian_wide.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_byg_sythian_wide.json
@@ -21,7 +21,7 @@
   "conditions": [
     {
       "condition": "neoforge:mod_loaded",
-      "modid": "byg"
+      "modid": "biomeswevegone"
     }
   ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_byg_white_mangrove.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_byg_white_mangrove.json
@@ -21,7 +21,7 @@
   "conditions": [
     {
       "condition": "neoforge:mod_loaded",
-      "modid": "byg"
+      "modid": "biomeswevegone"
     }
   ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_byg_white_mangrove_narrow.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_byg_white_mangrove_narrow.json
@@ -21,7 +21,7 @@
   "conditions": [
     {
       "condition": "neoforge:mod_loaded",
-      "modid": "byg"
+      "modid": "biomeswevegone"
     }
   ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_byg_white_mangrove_wide.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_byg_white_mangrove_wide.json
@@ -21,7 +21,7 @@
   "conditions": [
     {
       "condition": "neoforge:mod_loaded",
-      "modid": "byg"
+      "modid": "biomeswevegone"
     }
   ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_byg_willow.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_byg_willow.json
@@ -21,7 +21,7 @@
   "conditions": [
     {
       "condition": "neoforge:mod_loaded",
-      "modid": "byg"
+      "modid": "biomeswevegone"
     }
   ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_byg_willow_narrow.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_byg_willow_narrow.json
@@ -21,7 +21,7 @@
   "conditions": [
     {
       "condition": "neoforge:mod_loaded",
-      "modid": "byg"
+      "modid": "biomeswevegone"
     }
   ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_byg_willow_wide.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_byg_willow_wide.json
@@ -21,7 +21,7 @@
   "conditions": [
     {
       "condition": "neoforge:mod_loaded",
-      "modid": "byg"
+      "modid": "biomeswevegone"
     }
   ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_byg_witch_hazel.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_byg_witch_hazel.json
@@ -21,7 +21,7 @@
   "conditions": [
     {
       "condition": "neoforge:mod_loaded",
-      "modid": "byg"
+      "modid": "biomeswevegone"
     }
   ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_byg_witch_hazel_narrow.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_byg_witch_hazel_narrow.json
@@ -21,7 +21,7 @@
   "conditions": [
     {
       "condition": "neoforge:mod_loaded",
-      "modid": "byg"
+      "modid": "biomeswevegone"
     }
   ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_byg_witch_hazel_wide.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_byg_witch_hazel_wide.json
@@ -21,7 +21,7 @@
   "conditions": [
     {
       "condition": "neoforge:mod_loaded",
-      "modid": "byg"
+      "modid": "biomeswevegone"
     }
   ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_byg_zelkova.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_byg_zelkova.json
@@ -21,7 +21,7 @@
   "conditions": [
     {
       "condition": "neoforge:mod_loaded",
-      "modid": "byg"
+      "modid": "biomeswevegone"
     }
   ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_byg_zelkova_narrow.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_byg_zelkova_narrow.json
@@ -21,7 +21,7 @@
   "conditions": [
     {
       "condition": "neoforge:mod_loaded",
-      "modid": "byg"
+      "modid": "biomeswevegone"
     }
   ]
 }

--- a/src/generated/resources/data/railways/loot_table/blocks/track_byg_zelkova_wide.json
+++ b/src/generated/resources/data/railways/loot_table/blocks/track_byg_zelkova_wide.json
@@ -21,7 +21,7 @@
   "conditions": [
     {
       "condition": "neoforge:mod_loaded",
-      "modid": "byg"
+      "modid": "biomeswevegone"
     }
   ]
 }

--- a/src/generated/resources/data/railways/tags/item/compat_slabs/byg/aspen.json
+++ b/src/generated/resources/data/railways/tags/item/compat_slabs/byg/aspen.json
@@ -1,7 +1,7 @@
 {
   "values": [
     {
-      "id": "byg:aspen_slab",
+      "id": "biomeswevegone:aspen_slab",
       "required": false
     }
   ]

--- a/src/generated/resources/data/railways/tags/item/compat_slabs/byg/aspen_narrow.json
+++ b/src/generated/resources/data/railways/tags/item/compat_slabs/byg/aspen_narrow.json
@@ -1,7 +1,7 @@
 {
   "values": [
     {
-      "id": "byg:aspen_slab",
+      "id": "biomeswevegone:aspen_slab",
       "required": false
     }
   ]

--- a/src/generated/resources/data/railways/tags/item/compat_slabs/byg/aspen_wide.json
+++ b/src/generated/resources/data/railways/tags/item/compat_slabs/byg/aspen_wide.json
@@ -1,7 +1,7 @@
 {
   "values": [
     {
-      "id": "byg:aspen_slab",
+      "id": "biomeswevegone:aspen_slab",
       "required": false
     }
   ]

--- a/src/generated/resources/data/railways/tags/item/compat_slabs/byg/baobab.json
+++ b/src/generated/resources/data/railways/tags/item/compat_slabs/byg/baobab.json
@@ -1,7 +1,7 @@
 {
   "values": [
     {
-      "id": "byg:baobab_slab",
+      "id": "biomeswevegone:baobab_slab",
       "required": false
     }
   ]

--- a/src/generated/resources/data/railways/tags/item/compat_slabs/byg/baobab_narrow.json
+++ b/src/generated/resources/data/railways/tags/item/compat_slabs/byg/baobab_narrow.json
@@ -1,7 +1,7 @@
 {
   "values": [
     {
-      "id": "byg:baobab_slab",
+      "id": "biomeswevegone:baobab_slab",
       "required": false
     }
   ]

--- a/src/generated/resources/data/railways/tags/item/compat_slabs/byg/baobab_wide.json
+++ b/src/generated/resources/data/railways/tags/item/compat_slabs/byg/baobab_wide.json
@@ -1,7 +1,7 @@
 {
   "values": [
     {
-      "id": "byg:baobab_slab",
+      "id": "biomeswevegone:baobab_slab",
       "required": false
     }
   ]

--- a/src/generated/resources/data/railways/tags/item/compat_slabs/byg/blue_enchanted.json
+++ b/src/generated/resources/data/railways/tags/item/compat_slabs/byg/blue_enchanted.json
@@ -1,7 +1,7 @@
 {
   "values": [
     {
-      "id": "byg:blue_enchanted_slab",
+      "id": "biomeswevegone:blue_enchanted_slab",
       "required": false
     }
   ]

--- a/src/generated/resources/data/railways/tags/item/compat_slabs/byg/blue_enchanted_narrow.json
+++ b/src/generated/resources/data/railways/tags/item/compat_slabs/byg/blue_enchanted_narrow.json
@@ -1,7 +1,7 @@
 {
   "values": [
     {
-      "id": "byg:blue_enchanted_slab",
+      "id": "biomeswevegone:blue_enchanted_slab",
       "required": false
     }
   ]

--- a/src/generated/resources/data/railways/tags/item/compat_slabs/byg/blue_enchanted_wide.json
+++ b/src/generated/resources/data/railways/tags/item/compat_slabs/byg/blue_enchanted_wide.json
@@ -1,7 +1,7 @@
 {
   "values": [
     {
-      "id": "byg:blue_enchanted_slab",
+      "id": "biomeswevegone:blue_enchanted_slab",
       "required": false
     }
   ]

--- a/src/generated/resources/data/railways/tags/item/compat_slabs/byg/bulbis.json
+++ b/src/generated/resources/data/railways/tags/item/compat_slabs/byg/bulbis.json
@@ -1,7 +1,7 @@
 {
   "values": [
     {
-      "id": "byg:bulbis_slab",
+      "id": "biomeswevegone:bulbis_slab",
       "required": false
     }
   ]

--- a/src/generated/resources/data/railways/tags/item/compat_slabs/byg/bulbis_narrow.json
+++ b/src/generated/resources/data/railways/tags/item/compat_slabs/byg/bulbis_narrow.json
@@ -1,7 +1,7 @@
 {
   "values": [
     {
-      "id": "byg:bulbis_slab",
+      "id": "biomeswevegone:bulbis_slab",
       "required": false
     }
   ]

--- a/src/generated/resources/data/railways/tags/item/compat_slabs/byg/bulbis_wide.json
+++ b/src/generated/resources/data/railways/tags/item/compat_slabs/byg/bulbis_wide.json
@@ -1,7 +1,7 @@
 {
   "values": [
     {
-      "id": "byg:bulbis_slab",
+      "id": "biomeswevegone:bulbis_slab",
       "required": false
     }
   ]

--- a/src/generated/resources/data/railways/tags/item/compat_slabs/byg/cika.json
+++ b/src/generated/resources/data/railways/tags/item/compat_slabs/byg/cika.json
@@ -1,7 +1,7 @@
 {
   "values": [
     {
-      "id": "byg:cika_slab",
+      "id": "biomeswevegone:cika_slab",
       "required": false
     }
   ]

--- a/src/generated/resources/data/railways/tags/item/compat_slabs/byg/cika_narrow.json
+++ b/src/generated/resources/data/railways/tags/item/compat_slabs/byg/cika_narrow.json
@@ -1,7 +1,7 @@
 {
   "values": [
     {
-      "id": "byg:cika_slab",
+      "id": "biomeswevegone:cika_slab",
       "required": false
     }
   ]

--- a/src/generated/resources/data/railways/tags/item/compat_slabs/byg/cika_wide.json
+++ b/src/generated/resources/data/railways/tags/item/compat_slabs/byg/cika_wide.json
@@ -1,7 +1,7 @@
 {
   "values": [
     {
-      "id": "byg:cika_slab",
+      "id": "biomeswevegone:cika_slab",
       "required": false
     }
   ]

--- a/src/generated/resources/data/railways/tags/item/compat_slabs/byg/cypress.json
+++ b/src/generated/resources/data/railways/tags/item/compat_slabs/byg/cypress.json
@@ -1,7 +1,7 @@
 {
   "values": [
     {
-      "id": "byg:cypress_slab",
+      "id": "biomeswevegone:cypress_slab",
       "required": false
     }
   ]

--- a/src/generated/resources/data/railways/tags/item/compat_slabs/byg/cypress_narrow.json
+++ b/src/generated/resources/data/railways/tags/item/compat_slabs/byg/cypress_narrow.json
@@ -1,7 +1,7 @@
 {
   "values": [
     {
-      "id": "byg:cypress_slab",
+      "id": "biomeswevegone:cypress_slab",
       "required": false
     }
   ]

--- a/src/generated/resources/data/railways/tags/item/compat_slabs/byg/cypress_wide.json
+++ b/src/generated/resources/data/railways/tags/item/compat_slabs/byg/cypress_wide.json
@@ -1,7 +1,7 @@
 {
   "values": [
     {
-      "id": "byg:cypress_slab",
+      "id": "biomeswevegone:cypress_slab",
       "required": false
     }
   ]

--- a/src/generated/resources/data/railways/tags/item/compat_slabs/byg/ebony.json
+++ b/src/generated/resources/data/railways/tags/item/compat_slabs/byg/ebony.json
@@ -1,7 +1,7 @@
 {
   "values": [
     {
-      "id": "byg:ebony_slab",
+      "id": "biomeswevegone:ebony_slab",
       "required": false
     }
   ]

--- a/src/generated/resources/data/railways/tags/item/compat_slabs/byg/ebony_narrow.json
+++ b/src/generated/resources/data/railways/tags/item/compat_slabs/byg/ebony_narrow.json
@@ -1,7 +1,7 @@
 {
   "values": [
     {
-      "id": "byg:ebony_slab",
+      "id": "biomeswevegone:ebony_slab",
       "required": false
     }
   ]

--- a/src/generated/resources/data/railways/tags/item/compat_slabs/byg/ebony_wide.json
+++ b/src/generated/resources/data/railways/tags/item/compat_slabs/byg/ebony_wide.json
@@ -1,7 +1,7 @@
 {
   "values": [
     {
-      "id": "byg:ebony_slab",
+      "id": "biomeswevegone:ebony_slab",
       "required": false
     }
   ]

--- a/src/generated/resources/data/railways/tags/item/compat_slabs/byg/embur.json
+++ b/src/generated/resources/data/railways/tags/item/compat_slabs/byg/embur.json
@@ -1,7 +1,7 @@
 {
   "values": [
     {
-      "id": "byg:embur_slab",
+      "id": "biomeswevegone:embur_slab",
       "required": false
     }
   ]

--- a/src/generated/resources/data/railways/tags/item/compat_slabs/byg/embur_narrow.json
+++ b/src/generated/resources/data/railways/tags/item/compat_slabs/byg/embur_narrow.json
@@ -1,7 +1,7 @@
 {
   "values": [
     {
-      "id": "byg:embur_slab",
+      "id": "biomeswevegone:embur_slab",
       "required": false
     }
   ]

--- a/src/generated/resources/data/railways/tags/item/compat_slabs/byg/embur_wide.json
+++ b/src/generated/resources/data/railways/tags/item/compat_slabs/byg/embur_wide.json
@@ -1,7 +1,7 @@
 {
   "values": [
     {
-      "id": "byg:embur_slab",
+      "id": "biomeswevegone:embur_slab",
       "required": false
     }
   ]

--- a/src/generated/resources/data/railways/tags/item/compat_slabs/byg/ether.json
+++ b/src/generated/resources/data/railways/tags/item/compat_slabs/byg/ether.json
@@ -1,7 +1,7 @@
 {
   "values": [
     {
-      "id": "byg:ether_slab",
+      "id": "biomeswevegone:ether_slab",
       "required": false
     }
   ]

--- a/src/generated/resources/data/railways/tags/item/compat_slabs/byg/ether_narrow.json
+++ b/src/generated/resources/data/railways/tags/item/compat_slabs/byg/ether_narrow.json
@@ -1,7 +1,7 @@
 {
   "values": [
     {
-      "id": "byg:ether_slab",
+      "id": "biomeswevegone:ether_slab",
       "required": false
     }
   ]

--- a/src/generated/resources/data/railways/tags/item/compat_slabs/byg/ether_wide.json
+++ b/src/generated/resources/data/railways/tags/item/compat_slabs/byg/ether_wide.json
@@ -1,7 +1,7 @@
 {
   "values": [
     {
-      "id": "byg:ether_slab",
+      "id": "biomeswevegone:ether_slab",
       "required": false
     }
   ]

--- a/src/generated/resources/data/railways/tags/item/compat_slabs/byg/fir.json
+++ b/src/generated/resources/data/railways/tags/item/compat_slabs/byg/fir.json
@@ -1,7 +1,7 @@
 {
   "values": [
     {
-      "id": "byg:fir_slab",
+      "id": "biomeswevegone:fir_slab",
       "required": false
     }
   ]

--- a/src/generated/resources/data/railways/tags/item/compat_slabs/byg/fir_narrow.json
+++ b/src/generated/resources/data/railways/tags/item/compat_slabs/byg/fir_narrow.json
@@ -1,7 +1,7 @@
 {
   "values": [
     {
-      "id": "byg:fir_slab",
+      "id": "biomeswevegone:fir_slab",
       "required": false
     }
   ]

--- a/src/generated/resources/data/railways/tags/item/compat_slabs/byg/fir_wide.json
+++ b/src/generated/resources/data/railways/tags/item/compat_slabs/byg/fir_wide.json
@@ -1,7 +1,7 @@
 {
   "values": [
     {
-      "id": "byg:fir_slab",
+      "id": "biomeswevegone:fir_slab",
       "required": false
     }
   ]

--- a/src/generated/resources/data/railways/tags/item/compat_slabs/byg/green_enchanted.json
+++ b/src/generated/resources/data/railways/tags/item/compat_slabs/byg/green_enchanted.json
@@ -1,7 +1,7 @@
 {
   "values": [
     {
-      "id": "byg:green_enchanted_slab",
+      "id": "biomeswevegone:green_enchanted_slab",
       "required": false
     }
   ]

--- a/src/generated/resources/data/railways/tags/item/compat_slabs/byg/green_enchanted_narrow.json
+++ b/src/generated/resources/data/railways/tags/item/compat_slabs/byg/green_enchanted_narrow.json
@@ -1,7 +1,7 @@
 {
   "values": [
     {
-      "id": "byg:green_enchanted_slab",
+      "id": "biomeswevegone:green_enchanted_slab",
       "required": false
     }
   ]

--- a/src/generated/resources/data/railways/tags/item/compat_slabs/byg/green_enchanted_wide.json
+++ b/src/generated/resources/data/railways/tags/item/compat_slabs/byg/green_enchanted_wide.json
@@ -1,7 +1,7 @@
 {
   "values": [
     {
-      "id": "byg:green_enchanted_slab",
+      "id": "biomeswevegone:green_enchanted_slab",
       "required": false
     }
   ]

--- a/src/generated/resources/data/railways/tags/item/compat_slabs/byg/holly.json
+++ b/src/generated/resources/data/railways/tags/item/compat_slabs/byg/holly.json
@@ -1,7 +1,7 @@
 {
   "values": [
     {
-      "id": "byg:holly_slab",
+      "id": "biomeswevegone:holly_slab",
       "required": false
     }
   ]

--- a/src/generated/resources/data/railways/tags/item/compat_slabs/byg/holly_narrow.json
+++ b/src/generated/resources/data/railways/tags/item/compat_slabs/byg/holly_narrow.json
@@ -1,7 +1,7 @@
 {
   "values": [
     {
-      "id": "byg:holly_slab",
+      "id": "biomeswevegone:holly_slab",
       "required": false
     }
   ]

--- a/src/generated/resources/data/railways/tags/item/compat_slabs/byg/holly_wide.json
+++ b/src/generated/resources/data/railways/tags/item/compat_slabs/byg/holly_wide.json
@@ -1,7 +1,7 @@
 {
   "values": [
     {
-      "id": "byg:holly_slab",
+      "id": "biomeswevegone:holly_slab",
       "required": false
     }
   ]

--- a/src/generated/resources/data/railways/tags/item/compat_slabs/byg/imparius.json
+++ b/src/generated/resources/data/railways/tags/item/compat_slabs/byg/imparius.json
@@ -1,7 +1,7 @@
 {
   "values": [
     {
-      "id": "byg:imparius_slab",
+      "id": "biomeswevegone:imparius_slab",
       "required": false
     }
   ]

--- a/src/generated/resources/data/railways/tags/item/compat_slabs/byg/imparius_narrow.json
+++ b/src/generated/resources/data/railways/tags/item/compat_slabs/byg/imparius_narrow.json
@@ -1,7 +1,7 @@
 {
   "values": [
     {
-      "id": "byg:imparius_slab",
+      "id": "biomeswevegone:imparius_slab",
       "required": false
     }
   ]

--- a/src/generated/resources/data/railways/tags/item/compat_slabs/byg/imparius_wide.json
+++ b/src/generated/resources/data/railways/tags/item/compat_slabs/byg/imparius_wide.json
@@ -1,7 +1,7 @@
 {
   "values": [
     {
-      "id": "byg:imparius_slab",
+      "id": "biomeswevegone:imparius_slab",
       "required": false
     }
   ]

--- a/src/generated/resources/data/railways/tags/item/compat_slabs/byg/jacaranda.json
+++ b/src/generated/resources/data/railways/tags/item/compat_slabs/byg/jacaranda.json
@@ -1,7 +1,7 @@
 {
   "values": [
     {
-      "id": "byg:jacaranda_slab",
+      "id": "biomeswevegone:jacaranda_slab",
       "required": false
     }
   ]

--- a/src/generated/resources/data/railways/tags/item/compat_slabs/byg/jacaranda_narrow.json
+++ b/src/generated/resources/data/railways/tags/item/compat_slabs/byg/jacaranda_narrow.json
@@ -1,7 +1,7 @@
 {
   "values": [
     {
-      "id": "byg:jacaranda_slab",
+      "id": "biomeswevegone:jacaranda_slab",
       "required": false
     }
   ]

--- a/src/generated/resources/data/railways/tags/item/compat_slabs/byg/jacaranda_wide.json
+++ b/src/generated/resources/data/railways/tags/item/compat_slabs/byg/jacaranda_wide.json
@@ -1,7 +1,7 @@
 {
   "values": [
     {
-      "id": "byg:jacaranda_slab",
+      "id": "biomeswevegone:jacaranda_slab",
       "required": false
     }
   ]

--- a/src/generated/resources/data/railways/tags/item/compat_slabs/byg/lament.json
+++ b/src/generated/resources/data/railways/tags/item/compat_slabs/byg/lament.json
@@ -1,7 +1,7 @@
 {
   "values": [
     {
-      "id": "byg:lament_slab",
+      "id": "biomeswevegone:lament_slab",
       "required": false
     }
   ]

--- a/src/generated/resources/data/railways/tags/item/compat_slabs/byg/lament_narrow.json
+++ b/src/generated/resources/data/railways/tags/item/compat_slabs/byg/lament_narrow.json
@@ -1,7 +1,7 @@
 {
   "values": [
     {
-      "id": "byg:lament_slab",
+      "id": "biomeswevegone:lament_slab",
       "required": false
     }
   ]

--- a/src/generated/resources/data/railways/tags/item/compat_slabs/byg/lament_wide.json
+++ b/src/generated/resources/data/railways/tags/item/compat_slabs/byg/lament_wide.json
@@ -1,7 +1,7 @@
 {
   "values": [
     {
-      "id": "byg:lament_slab",
+      "id": "biomeswevegone:lament_slab",
       "required": false
     }
   ]

--- a/src/generated/resources/data/railways/tags/item/compat_slabs/byg/mahogany.json
+++ b/src/generated/resources/data/railways/tags/item/compat_slabs/byg/mahogany.json
@@ -1,7 +1,7 @@
 {
   "values": [
     {
-      "id": "byg:mahogany_slab",
+      "id": "biomeswevegone:mahogany_slab",
       "required": false
     }
   ]

--- a/src/generated/resources/data/railways/tags/item/compat_slabs/byg/mahogany_narrow.json
+++ b/src/generated/resources/data/railways/tags/item/compat_slabs/byg/mahogany_narrow.json
@@ -1,7 +1,7 @@
 {
   "values": [
     {
-      "id": "byg:mahogany_slab",
+      "id": "biomeswevegone:mahogany_slab",
       "required": false
     }
   ]

--- a/src/generated/resources/data/railways/tags/item/compat_slabs/byg/mahogany_wide.json
+++ b/src/generated/resources/data/railways/tags/item/compat_slabs/byg/mahogany_wide.json
@@ -1,7 +1,7 @@
 {
   "values": [
     {
-      "id": "byg:mahogany_slab",
+      "id": "biomeswevegone:mahogany_slab",
       "required": false
     }
   ]

--- a/src/generated/resources/data/railways/tags/item/compat_slabs/byg/maple.json
+++ b/src/generated/resources/data/railways/tags/item/compat_slabs/byg/maple.json
@@ -1,7 +1,7 @@
 {
   "values": [
     {
-      "id": "byg:maple_slab",
+      "id": "biomeswevegone:maple_slab",
       "required": false
     }
   ]

--- a/src/generated/resources/data/railways/tags/item/compat_slabs/byg/maple_narrow.json
+++ b/src/generated/resources/data/railways/tags/item/compat_slabs/byg/maple_narrow.json
@@ -1,7 +1,7 @@
 {
   "values": [
     {
-      "id": "byg:maple_slab",
+      "id": "biomeswevegone:maple_slab",
       "required": false
     }
   ]

--- a/src/generated/resources/data/railways/tags/item/compat_slabs/byg/maple_wide.json
+++ b/src/generated/resources/data/railways/tags/item/compat_slabs/byg/maple_wide.json
@@ -1,7 +1,7 @@
 {
   "values": [
     {
-      "id": "byg:maple_slab",
+      "id": "biomeswevegone:maple_slab",
       "required": false
     }
   ]

--- a/src/generated/resources/data/railways/tags/item/compat_slabs/byg/nightshade.json
+++ b/src/generated/resources/data/railways/tags/item/compat_slabs/byg/nightshade.json
@@ -1,7 +1,7 @@
 {
   "values": [
     {
-      "id": "byg:nightshade_slab",
+      "id": "biomeswevegone:nightshade_slab",
       "required": false
     }
   ]

--- a/src/generated/resources/data/railways/tags/item/compat_slabs/byg/nightshade_narrow.json
+++ b/src/generated/resources/data/railways/tags/item/compat_slabs/byg/nightshade_narrow.json
@@ -1,7 +1,7 @@
 {
   "values": [
     {
-      "id": "byg:nightshade_slab",
+      "id": "biomeswevegone:nightshade_slab",
       "required": false
     }
   ]

--- a/src/generated/resources/data/railways/tags/item/compat_slabs/byg/nightshade_wide.json
+++ b/src/generated/resources/data/railways/tags/item/compat_slabs/byg/nightshade_wide.json
@@ -1,7 +1,7 @@
 {
   "values": [
     {
-      "id": "byg:nightshade_slab",
+      "id": "biomeswevegone:nightshade_slab",
       "required": false
     }
   ]

--- a/src/generated/resources/data/railways/tags/item/compat_slabs/byg/palm.json
+++ b/src/generated/resources/data/railways/tags/item/compat_slabs/byg/palm.json
@@ -1,7 +1,7 @@
 {
   "values": [
     {
-      "id": "byg:palm_slab",
+      "id": "biomeswevegone:palm_slab",
       "required": false
     }
   ]

--- a/src/generated/resources/data/railways/tags/item/compat_slabs/byg/palm_narrow.json
+++ b/src/generated/resources/data/railways/tags/item/compat_slabs/byg/palm_narrow.json
@@ -1,7 +1,7 @@
 {
   "values": [
     {
-      "id": "byg:palm_slab",
+      "id": "biomeswevegone:palm_slab",
       "required": false
     }
   ]

--- a/src/generated/resources/data/railways/tags/item/compat_slabs/byg/palm_wide.json
+++ b/src/generated/resources/data/railways/tags/item/compat_slabs/byg/palm_wide.json
@@ -1,7 +1,7 @@
 {
   "values": [
     {
-      "id": "byg:palm_slab",
+      "id": "biomeswevegone:palm_slab",
       "required": false
     }
   ]

--- a/src/generated/resources/data/railways/tags/item/compat_slabs/byg/pine.json
+++ b/src/generated/resources/data/railways/tags/item/compat_slabs/byg/pine.json
@@ -1,7 +1,7 @@
 {
   "values": [
     {
-      "id": "byg:pine_slab",
+      "id": "biomeswevegone:pine_slab",
       "required": false
     }
   ]

--- a/src/generated/resources/data/railways/tags/item/compat_slabs/byg/pine_narrow.json
+++ b/src/generated/resources/data/railways/tags/item/compat_slabs/byg/pine_narrow.json
@@ -1,7 +1,7 @@
 {
   "values": [
     {
-      "id": "byg:pine_slab",
+      "id": "biomeswevegone:pine_slab",
       "required": false
     }
   ]

--- a/src/generated/resources/data/railways/tags/item/compat_slabs/byg/pine_wide.json
+++ b/src/generated/resources/data/railways/tags/item/compat_slabs/byg/pine_wide.json
@@ -1,7 +1,7 @@
 {
   "values": [
     {
-      "id": "byg:pine_slab",
+      "id": "biomeswevegone:pine_slab",
       "required": false
     }
   ]

--- a/src/generated/resources/data/railways/tags/item/compat_slabs/byg/rainbow_eucalyptus.json
+++ b/src/generated/resources/data/railways/tags/item/compat_slabs/byg/rainbow_eucalyptus.json
@@ -1,7 +1,7 @@
 {
   "values": [
     {
-      "id": "byg:rainbow_eucalyptus_slab",
+      "id": "biomeswevegone:rainbow_eucalyptus_slab",
       "required": false
     }
   ]

--- a/src/generated/resources/data/railways/tags/item/compat_slabs/byg/rainbow_eucalyptus_narrow.json
+++ b/src/generated/resources/data/railways/tags/item/compat_slabs/byg/rainbow_eucalyptus_narrow.json
@@ -1,7 +1,7 @@
 {
   "values": [
     {
-      "id": "byg:rainbow_eucalyptus_slab",
+      "id": "biomeswevegone:rainbow_eucalyptus_slab",
       "required": false
     }
   ]

--- a/src/generated/resources/data/railways/tags/item/compat_slabs/byg/rainbow_eucalyptus_wide.json
+++ b/src/generated/resources/data/railways/tags/item/compat_slabs/byg/rainbow_eucalyptus_wide.json
@@ -1,7 +1,7 @@
 {
   "values": [
     {
-      "id": "byg:rainbow_eucalyptus_slab",
+      "id": "biomeswevegone:rainbow_eucalyptus_slab",
       "required": false
     }
   ]

--- a/src/generated/resources/data/railways/tags/item/compat_slabs/byg/redwood.json
+++ b/src/generated/resources/data/railways/tags/item/compat_slabs/byg/redwood.json
@@ -1,7 +1,7 @@
 {
   "values": [
     {
-      "id": "byg:redwood_slab",
+      "id": "biomeswevegone:redwood_slab",
       "required": false
     }
   ]

--- a/src/generated/resources/data/railways/tags/item/compat_slabs/byg/redwood_narrow.json
+++ b/src/generated/resources/data/railways/tags/item/compat_slabs/byg/redwood_narrow.json
@@ -1,7 +1,7 @@
 {
   "values": [
     {
-      "id": "byg:redwood_slab",
+      "id": "biomeswevegone:redwood_slab",
       "required": false
     }
   ]

--- a/src/generated/resources/data/railways/tags/item/compat_slabs/byg/redwood_wide.json
+++ b/src/generated/resources/data/railways/tags/item/compat_slabs/byg/redwood_wide.json
@@ -1,7 +1,7 @@
 {
   "values": [
     {
-      "id": "byg:redwood_slab",
+      "id": "biomeswevegone:redwood_slab",
       "required": false
     }
   ]

--- a/src/generated/resources/data/railways/tags/item/compat_slabs/byg/skyris.json
+++ b/src/generated/resources/data/railways/tags/item/compat_slabs/byg/skyris.json
@@ -1,7 +1,7 @@
 {
   "values": [
     {
-      "id": "byg:skyris_slab",
+      "id": "biomeswevegone:skyris_slab",
       "required": false
     }
   ]

--- a/src/generated/resources/data/railways/tags/item/compat_slabs/byg/skyris_narrow.json
+++ b/src/generated/resources/data/railways/tags/item/compat_slabs/byg/skyris_narrow.json
@@ -1,7 +1,7 @@
 {
   "values": [
     {
-      "id": "byg:skyris_slab",
+      "id": "biomeswevegone:skyris_slab",
       "required": false
     }
   ]

--- a/src/generated/resources/data/railways/tags/item/compat_slabs/byg/skyris_wide.json
+++ b/src/generated/resources/data/railways/tags/item/compat_slabs/byg/skyris_wide.json
@@ -1,7 +1,7 @@
 {
   "values": [
     {
-      "id": "byg:skyris_slab",
+      "id": "biomeswevegone:skyris_slab",
       "required": false
     }
   ]

--- a/src/generated/resources/data/railways/tags/item/compat_slabs/byg/sythian.json
+++ b/src/generated/resources/data/railways/tags/item/compat_slabs/byg/sythian.json
@@ -1,7 +1,7 @@
 {
   "values": [
     {
-      "id": "byg:sythian_slab",
+      "id": "biomeswevegone:sythian_slab",
       "required": false
     }
   ]

--- a/src/generated/resources/data/railways/tags/item/compat_slabs/byg/sythian_narrow.json
+++ b/src/generated/resources/data/railways/tags/item/compat_slabs/byg/sythian_narrow.json
@@ -1,7 +1,7 @@
 {
   "values": [
     {
-      "id": "byg:sythian_slab",
+      "id": "biomeswevegone:sythian_slab",
       "required": false
     }
   ]

--- a/src/generated/resources/data/railways/tags/item/compat_slabs/byg/sythian_wide.json
+++ b/src/generated/resources/data/railways/tags/item/compat_slabs/byg/sythian_wide.json
@@ -1,7 +1,7 @@
 {
   "values": [
     {
-      "id": "byg:sythian_slab",
+      "id": "biomeswevegone:sythian_slab",
       "required": false
     }
   ]

--- a/src/generated/resources/data/railways/tags/item/compat_slabs/byg/white_mangrove.json
+++ b/src/generated/resources/data/railways/tags/item/compat_slabs/byg/white_mangrove.json
@@ -1,7 +1,7 @@
 {
   "values": [
     {
-      "id": "byg:white_mangrove_slab",
+      "id": "biomeswevegone:white_mangrove_slab",
       "required": false
     }
   ]

--- a/src/generated/resources/data/railways/tags/item/compat_slabs/byg/white_mangrove_narrow.json
+++ b/src/generated/resources/data/railways/tags/item/compat_slabs/byg/white_mangrove_narrow.json
@@ -1,7 +1,7 @@
 {
   "values": [
     {
-      "id": "byg:white_mangrove_slab",
+      "id": "biomeswevegone:white_mangrove_slab",
       "required": false
     }
   ]

--- a/src/generated/resources/data/railways/tags/item/compat_slabs/byg/white_mangrove_wide.json
+++ b/src/generated/resources/data/railways/tags/item/compat_slabs/byg/white_mangrove_wide.json
@@ -1,7 +1,7 @@
 {
   "values": [
     {
-      "id": "byg:white_mangrove_slab",
+      "id": "biomeswevegone:white_mangrove_slab",
       "required": false
     }
   ]

--- a/src/generated/resources/data/railways/tags/item/compat_slabs/byg/willow.json
+++ b/src/generated/resources/data/railways/tags/item/compat_slabs/byg/willow.json
@@ -1,7 +1,7 @@
 {
   "values": [
     {
-      "id": "byg:willow_slab",
+      "id": "biomeswevegone:willow_slab",
       "required": false
     }
   ]

--- a/src/generated/resources/data/railways/tags/item/compat_slabs/byg/willow_narrow.json
+++ b/src/generated/resources/data/railways/tags/item/compat_slabs/byg/willow_narrow.json
@@ -1,7 +1,7 @@
 {
   "values": [
     {
-      "id": "byg:willow_slab",
+      "id": "biomeswevegone:willow_slab",
       "required": false
     }
   ]

--- a/src/generated/resources/data/railways/tags/item/compat_slabs/byg/willow_wide.json
+++ b/src/generated/resources/data/railways/tags/item/compat_slabs/byg/willow_wide.json
@@ -1,7 +1,7 @@
 {
   "values": [
     {
-      "id": "byg:willow_slab",
+      "id": "biomeswevegone:willow_slab",
       "required": false
     }
   ]

--- a/src/generated/resources/data/railways/tags/item/compat_slabs/byg/witch_hazel.json
+++ b/src/generated/resources/data/railways/tags/item/compat_slabs/byg/witch_hazel.json
@@ -1,7 +1,7 @@
 {
   "values": [
     {
-      "id": "byg:witch_hazel_slab",
+      "id": "biomeswevegone:witch_hazel_slab",
       "required": false
     }
   ]

--- a/src/generated/resources/data/railways/tags/item/compat_slabs/byg/witch_hazel_narrow.json
+++ b/src/generated/resources/data/railways/tags/item/compat_slabs/byg/witch_hazel_narrow.json
@@ -1,7 +1,7 @@
 {
   "values": [
     {
-      "id": "byg:witch_hazel_slab",
+      "id": "biomeswevegone:witch_hazel_slab",
       "required": false
     }
   ]

--- a/src/generated/resources/data/railways/tags/item/compat_slabs/byg/witch_hazel_wide.json
+++ b/src/generated/resources/data/railways/tags/item/compat_slabs/byg/witch_hazel_wide.json
@@ -1,7 +1,7 @@
 {
   "values": [
     {
-      "id": "byg:witch_hazel_slab",
+      "id": "biomeswevegone:witch_hazel_slab",
       "required": false
     }
   ]

--- a/src/generated/resources/data/railways/tags/item/compat_slabs/byg/zelkova.json
+++ b/src/generated/resources/data/railways/tags/item/compat_slabs/byg/zelkova.json
@@ -1,7 +1,7 @@
 {
   "values": [
     {
-      "id": "byg:zelkova_slab",
+      "id": "biomeswevegone:zelkova_slab",
       "required": false
     }
   ]

--- a/src/generated/resources/data/railways/tags/item/compat_slabs/byg/zelkova_narrow.json
+++ b/src/generated/resources/data/railways/tags/item/compat_slabs/byg/zelkova_narrow.json
@@ -1,7 +1,7 @@
 {
   "values": [
     {
-      "id": "byg:zelkova_slab",
+      "id": "biomeswevegone:zelkova_slab",
       "required": false
     }
   ]

--- a/src/generated/resources/data/railways/tags/item/compat_slabs/byg/zelkova_wide.json
+++ b/src/generated/resources/data/railways/tags/item/compat_slabs/byg/zelkova_wide.json
@@ -1,7 +1,7 @@
 {
   "values": [
     {
-      "id": "byg:zelkova_slab",
+      "id": "biomeswevegone:zelkova_slab",
       "required": false
     }
   ]

--- a/src/main/java/com/railwayteam/railways/neoforge/datagen/CompatTrackLootTableProvider.java
+++ b/src/main/java/com/railwayteam/railways/neoforge/datagen/CompatTrackLootTableProvider.java
@@ -38,7 +38,7 @@ public class CompatTrackLootTableProvider implements DataProvider {
     private static final Map<String, String> MOD_ID_MAP = Map.ofEntries(
         Map.entry("biomesoplenty", "biomesoplenty"),
         Map.entry("blue_skies", "blue_skies"),
-        Map.entry("byg", "byg"),
+        Map.entry("byg", "biomeswevegone"),
         Map.entry("create_dd", "create_dd"),
         Map.entry("hexcasting", "hexcasting"),
         Map.entry("natures_spirit", "natures_spirit"),

--- a/src/main/java/com/railwayteam/railways/neoforge/datagen/CompatTrackTagProvider.java
+++ b/src/main/java/com/railwayteam/railways/neoforge/datagen/CompatTrackTagProvider.java
@@ -12,9 +12,14 @@ import com.simibubi.create.content.trains.track.TrackMaterial;
 import com.railwayteam.railways.compat.tracks.TrackCompatUtils;
 
 import java.util.ArrayList;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
 public class CompatTrackTagProvider extends TagsProvider<Item> {
+    private static final Map<String, String> RENAMED_COMPAT_NAMESPACES = Map.of(
+        "byg", "biomeswevegone"
+    );
+
     public CompatTrackTagProvider(PackOutput packOutput, CompletableFuture<HolderLookup.Provider> lookupProvider) {
         super(packOutput, Registries.ITEM, lookupProvider);
     }
@@ -27,7 +32,8 @@ public class CompatTrackTagProvider extends TagsProvider<Item> {
                 TagKey<Item> tagKey = TagKey.create(Registries.ITEM, tagId);
 
                 String woodName = material.resourceName().replace("_narrow", "").replace("_wide", "");
-                ResourceLocation actualCompatSlabId = resolveCompatSlabId(material.id.getNamespace(), woodName);
+                String namespace = RENAMED_COMPAT_NAMESPACES.getOrDefault(material.id.getNamespace(), material.id.getNamespace());
+                ResourceLocation actualCompatSlabId = resolveCompatSlabId(namespace, woodName);
                 this.tag(tagKey).addOptional(actualCompatSlabId);
             }
         }


### PR DESCRIPTION
BYG renamed its NeoForge mod id to `biomeswevegone` at some point, but two spots in the compat track datagen still hardcoded the old `byg` id:

- `CompatTrackTagProvider` baked the optional slab ingredient as `byg:<wood>_slab`, which doesn't exist anymore, so every BYG/BWG track recipe was uncraftable (all 28 wood types x 3 gauges).
- `CompatTrackLootTableProvider`'s `MOD_ID_MAP` gated the compat loot tables on `neoforge:mod_loaded` for `byg`, which will never match the installed mod.

Railways' own internal ids (registered items, tag keys, recipe references) all stay namespaced as `byg` — that's just our internal bookkeeping prefix and nothing external reads it, so no rename/migration needed there. Only the two spots that emit a reference to the external mod needed the id swap, via a small rename map so it can't drift between the two again.

Regenerated the affected datagen output (84 compat slab tags, 84 loot tables).

Fixes #323